### PR TITLE
Update message to mention Fly instead of Heroku

### DIFF
--- a/src/checks/linkOnGithubAbout.ts
+++ b/src/checks/linkOnGithubAbout.ts
@@ -32,7 +32,7 @@ export default async function linkOnGithubAbout() {
 
   if (!urlInAboutSection) {
     throw new Error(
-      `Deployed project link not found in About section on ${repoUrl}. Click on the cog symbol to the right of the About heading and paste the Repl.it / Netlify / Heroku link in the Website box.`,
+      `Deployed project link not found in About section on ${repoUrl}. Click on the cog symbol to the right of the About heading and paste the Repl.it / Netlify / Fly.io link in the Website box.`,
     );
   }
 


### PR DESCRIPTION
As part of the migration to Fly.io we need to update the preflight message