### PR TITLE
Add exceptions for Stylelint configuration

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -18,7 +18,7 @@ export default async function noUnusedAndMissingDependencies() {
     'postcss',
     'tailwindcss',
 
-    // Sass (eg. in create-react-app)
+    // Sass (eg. in create-react-app and Next.js)
     'sass',
 
     // Stylelint configuration

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -26,6 +26,7 @@ export default async function noUnusedAndMissingDependencies() {
     'stylelint-config-recommended-scss',
 
     // ESLint configuration
+    '@typescript-eslint/utils',
     'babel-eslint',
     'eslint-config-next',
 

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -21,6 +21,10 @@ export default async function noUnusedAndMissingDependencies() {
     // Sass (eg. in create-react-app)
     'sass',
 
+    // Stylelint configuration
+    'stylelint-config-css-modules',
+    'stylelint-config-recommended-scss',
+
     // ESLint configuration
     'babel-eslint',
     'eslint-config-next',


### PR DESCRIPTION
## Description

Adding some new ignores to the `depcheck` unused dependency check:

- Stylelint packages, because of the switch to Next.js 13 and the `app/` directory + CSS Modules + scss in the next cohorts
- missing `@typescript-eslint/` package
 
## Deployment and Testing Plan

- CI passes
- [ ] `create-react-app`
- [ ] `create-next-app`
