### PR TITLE
Add optional arg to run Docker on secondary branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ preflight
 
 ## Install and Run with Docker
 
-Pull and run the image, along with a URL to the GitHub repository that you want to test:
-
 ```bash
+# Pull the image
 docker pull ghcr.io/upleveled/preflight
+
+# Run the image against a GitHub repo URL
 docker run ghcr.io/upleveled/preflight https://github.com/upleveled/preflight-test-project-react-passing
+
+# Or run the image against a specific branch in a GitHub repo URL
+docker run ghcr.io/upleveled/preflight https://github.com/upleveled/preflight-test-project-react-passing fix-tests
 ```

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -32,6 +32,10 @@ await executeCommand(
   `git clone --depth 1 --single-branch ${process.argv[2]} ${repoPath} --config core.autocrlf=input`,
 );
 
+if (process.argv[3]) {
+  await executeCommand(`git switch ${process.argv[3]}`);
+}
+
 await executeCommand('yarn install --ignore-scripts', repoPath);
 const preflightOutput = await executeCommand('preflight', repoPath);
 


### PR DESCRIPTION
To use the Preflight Docker container as a GitHub action, we need to add support to clone projects from a different branch. For example, for portfolio projects Preflight test fails on PRs because it doesn't clone the PR branch but the main branch.

This PR solves the problem by adding a new argument that can be passed to the Docker container to switch branches after cloning the repo and before performing the Preflight check.