### PR TITLE
Filter out missing dependencies for false positive

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -120,6 +120,7 @@ export default async function noUnusedAndMissingDependencies() {
       `);
     }
 
-    throw new Error(messages.join('\n\n'));
+    // TODO: Remove the condition once the issue 789 is fixed in depcheck
+    if (messages.length) throw new Error(messages.join('\n\n'));
   }
 }

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -121,6 +121,6 @@ export default async function noUnusedAndMissingDependencies() {
       `);
     }
 
-    if (messages.length) throw new Error(messages.join('\n\n'));
+    if (messages.length > 0) throw new Error(messages.join('\n\n'));
   }
 }

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -75,7 +75,13 @@ export default async function noUnusedAndMissingDependencies() {
       `);
     }
 
-    if (missingDependenciesStdout) {
+    if (
+      // Don't run if the only missing dependencies are coming from the .eslintrc.cjs file
+      missingDependenciesStdout
+        .trim()
+        .split('\n')
+        .filter((str) => !str.includes('./.eslintrc.cjs')).length
+    ) {
       messages.push(`Missing dependencies found:
         ${missingDependenciesStdout
           .split('\n')

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -75,15 +75,41 @@ export default async function noUnusedAndMissingDependencies() {
       `);
     }
 
-    if (
-      // Don't run if the only missing dependencies are coming from the .eslintrc.cjs file
-      missingDependenciesStdout
-        .trim()
-        .split('\n')
-        .filter((str) => !str.includes('./.eslintrc.cjs')).length
-    ) {
+    /** Filter out @upleveled/eslint-config-upleveled peer dependencies not listed in package.json and flagged as missing dependencies by depcheck
+     * TODO: Remove this codeblock once the issue 789 is fixed in depcheck
+     * https://github.com/depcheck/depcheck/issues/789
+     */
+    const missingDependenciesStdoutFiltered = missingDependenciesStdout
+      .split('\n')
+      .filter(
+        (missingDependency) =>
+          !(
+            missingDependency.includes('./.eslintrc.cjs') &&
+            [
+              '@typescript-eslint/parser',
+              '@next/eslint-plugin-next',
+              '@typescript-eslint/eslint-plugin',
+              '@upleveled/eslint-plugin-upleveled',
+              'eslint-plugin-import',
+              'eslint-plugin-jsx-a11y',
+              'eslint-plugin-jsx-expressions',
+              'eslint-plugin-react',
+              'eslint-plugin-react-hooks',
+              'eslint-plugin-security',
+              'eslint-plugin-sonarjs',
+              'eslint-plugin-unicorn',
+              'eslint-config-react-app',
+              'eslint-import-resolver-typescript',
+            ].some((excludedDependency) =>
+              missingDependency.includes(excludedDependency),
+            )
+          ),
+      )
+      .join('\n');
+
+    if (missingDependenciesStdoutFiltered) {
       messages.push(`Missing dependencies found:
-        ${missingDependenciesStdout
+        ${missingDependenciesStdoutFiltered
           .split('\n')
           .filter((str: string) => str.includes('* '))
           .join('\n')}

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -88,20 +88,20 @@ export default async function noUnusedAndMissingDependencies() {
         return !(
           missingDependency.includes('./.eslintrc.cjs') &&
           [
-            '@typescript-eslint/parser',
             '@next/eslint-plugin-next',
             '@typescript-eslint/eslint-plugin',
+            '@typescript-eslint/parser',
             '@upleveled/eslint-plugin-upleveled',
+            'eslint-config-react-app',
+            'eslint-import-resolver-typescript',
             'eslint-plugin-import',
             'eslint-plugin-jsx-a11y',
             'eslint-plugin-jsx-expressions',
-            'eslint-plugin-react',
             'eslint-plugin-react-hooks',
+            'eslint-plugin-react',
             'eslint-plugin-security',
             'eslint-plugin-sonarjs',
             'eslint-plugin-unicorn',
-            'eslint-config-react-app',
-            'eslint-import-resolver-typescript',
           ].some((excludedDependency) =>
             missingDependency.includes(excludedDependency),
           )

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -75,7 +75,8 @@ export default async function noUnusedAndMissingDependencies() {
       `);
     }
 
-    /** Filter out @upleveled/eslint-config-upleveled peer dependencies not listed in package.json and flagged as missing dependencies by depcheck
+    /**
+     * Filter out @upleveled/eslint-config-upleveled peer dependencies not listed in package.json and flagged as missing dependencies by depcheck
      * TODO: Remove the filter once the issue 789 is fixed in depcheck
      * https://github.com/depcheck/depcheck/issues/789
      */

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -71,7 +71,7 @@ export default async function noUnusedAndMissingDependencies() {
 
         Remove these dependencies by running the following command for each dependency:
 
-        ${commandExample('yarn remove <dependency name here>')}
+        ${commandExample('pnpm remove <dependency name here>')}
       `);
     }
 

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -121,7 +121,6 @@ export default async function noUnusedAndMissingDependencies() {
       `);
     }
 
-    // TODO: Remove the condition once the issue 789 is fixed in depcheck
     if (messages.length) throw new Error(messages.join('\n\n'));
   }
 }

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -84,30 +84,29 @@ export default async function noUnusedAndMissingDependencies() {
      */
     const missingDependenciesStdoutFiltered = missingDependenciesStdout
       .split('\n')
-      .filter(
-        (missingDependency) =>
-          !(
-            missingDependency.includes('./.eslintrc.cjs') &&
-            [
-              '@typescript-eslint/parser',
-              '@next/eslint-plugin-next',
-              '@typescript-eslint/eslint-plugin',
-              '@upleveled/eslint-plugin-upleveled',
-              'eslint-plugin-import',
-              'eslint-plugin-jsx-a11y',
-              'eslint-plugin-jsx-expressions',
-              'eslint-plugin-react',
-              'eslint-plugin-react-hooks',
-              'eslint-plugin-security',
-              'eslint-plugin-sonarjs',
-              'eslint-plugin-unicorn',
-              'eslint-config-react-app',
-              'eslint-import-resolver-typescript',
-            ].some((excludedDependency) =>
-              missingDependency.includes(excludedDependency),
-            )
-          ),
-      )
+      .filter((missingDependency) => {
+        return !(
+          missingDependency.includes('./.eslintrc.cjs') &&
+          [
+            '@typescript-eslint/parser',
+            '@next/eslint-plugin-next',
+            '@typescript-eslint/eslint-plugin',
+            '@upleveled/eslint-plugin-upleveled',
+            'eslint-plugin-import',
+            'eslint-plugin-jsx-a11y',
+            'eslint-plugin-jsx-expressions',
+            'eslint-plugin-react',
+            'eslint-plugin-react-hooks',
+            'eslint-plugin-security',
+            'eslint-plugin-sonarjs',
+            'eslint-plugin-unicorn',
+            'eslint-config-react-app',
+            'eslint-import-resolver-typescript',
+          ].some((excludedDependency) =>
+            missingDependency.includes(excludedDependency),
+          )
+        );
+      })
       .join('\n');
 
     if (missingDependenciesStdoutFiltered) {

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -76,7 +76,7 @@ export default async function noUnusedAndMissingDependencies() {
     }
 
     /** Filter out @upleveled/eslint-config-upleveled peer dependencies not listed in package.json and flagged as missing dependencies by depcheck
-     * TODO: Remove this codeblock once the issue 789 is fixed in depcheck
+     * TODO: Remove the filter once the issue 789 is fixed in depcheck
      * https://github.com/depcheck/depcheck/issues/789
      */
     const missingDependenciesStdoutFiltered = missingDependenciesStdout

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -118,7 +118,7 @@ export default async function noUnusedAndMissingDependencies() {
 
         Add these missing dependencies by running the following command for each dependency:
 
-        ${commandExample('yarn add <dependency name here>')}
+        ${commandExample('pnpm add <dependency name here>')}
       `);
     }
 

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -76,8 +76,10 @@ export default async function noUnusedAndMissingDependencies() {
     }
 
     /**
-     * Filter out @upleveled/eslint-config-upleveled peer dependencies not listed in package.json and flagged as missing dependencies by depcheck
-     * TODO: Remove the filter once the issue 789 is fixed in depcheck
+     * Temporary workaround to filter out @upleveled/eslint-config-upleveled peer dependencies
+     * not listed in `package.json`, which are flagged as missing dependencies by depcheck
+     *
+     * TODO: Remove this variable once this depcheck issue is fixed:
      * https://github.com/depcheck/depcheck/issues/789
      */
     const missingDependenciesStdoutFiltered = missingDependenciesStdout


### PR DESCRIPTION
closes https://github.com/upleveled/preflight/issues/371

depcheck is flagging perdeps in @upleveled/eslint-config-upleveled and not listed in package.json as missing dependencies. This is not anymore necessary since npm v7+ and pnpm v8+

This has also been reported as an issue to depcheck:

- https://github.com/depcheck/depcheck/issues/789

This PR fix temporary this problem by removing the peerdeps from the user output; this is a workaround and should be reverted once 789 is fixed.

before the PR this is the output from Preflight

```
➜  peer-deps git:(main) preflight
🚀 UpLeveled Preflight v1.23.2
✔ All changes committed to Git
✔ node_modules/ folder ignored in Git
✔ No extraneous files committed to Git
✔ No secrets committed to Git
✔ Use single package manager
✔ Project folder name matches correct format
❯ No dependency problems
  ✖ No unused dependencies
    › Missing dependencies found:
      * @typescript-eslint/parser: ./.eslintrc.cjs
      * @next/eslint-plugin-next: ./.eslintrc.cjs
      * @typescript-eslint/eslint-plugin: ./.eslintrc.cjs
      * @upleveled/eslint-plugin-upleveled: ./.eslintrc.cjs
      * eslint-plugin-import: ./.eslintrc.cjs
      * eslint-plugin-jsx-a11y: ./.eslintrc.cjs
      * eslint-plugin-jsx-expressions: ./.eslintrc.cjs
      * eslint-plugin-react: ./.eslintrc.cjs
      * eslint-plugin-react-hooks: ./.eslintrc.cjs
      * eslint-plugin-security: ./.eslintrc.cjs
      * eslint-plugin-sonarjs: ./.eslintrc.cjs
      * eslint-plugin-unicorn: ./.eslintrc.cjs
      * eslint-config-react-app: ./.eslintrc.cjs
      * eslint-import-resolver-typescript: ./.eslintrc.cjs
      * randomcolor: ./index.js

      Add these missing dependencies by running the following command for each dependency:

      ‎  $ yarn add <dependency name here>

  ◼ No dependencies without types
✔ GitHub repo has deployed project link under About
✔ ESLint
✔ Prettier
✔ ESLint config is latest version
✔ Preflight is latest version
```

after the PR this is the output from preflight;

```
➜  peer-deps git:(main) preflight
🚀 UpLeveled Preflight v1.23.2
✔ All changes committed to Git
✔ node_modules/ folder ignored in Git
✔ No extraneous files committed to Git
✔ No secrets committed to Git
✔ Use single package manager
✔ Project folder name matches correct format
❯ No dependency problems
  ✖ No unused dependencies
    › Missing dependencies found:
      * randomcolor: ./index.js

      Add these missing dependencies by running the following command for each dependency:

      ‎  $ pnpm add <dependency name here>

  ◼ No dependencies without types
✔ GitHub repo has deployed project link under About
✔ ESLint
✔ Prettier
✔ ESLint config is latest version
✔ Preflight is latest version
```

