### PR TITLE
Update ESLint config package name and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-jest": "29.5.0",
     "eslint": "8.38.0",
     "eslint-config-react-app": "7.0.1",
-    "eslint-config-upleveled": "4.0.12",
+    "eslint-config-upleveled": "4.0.13",
     "eslint-import-resolver-typescript": "3.5.5",
     "eslint-plugin-cypress": "2.13.2",
     "eslint-plugin-flowtype": "8.0.3",

--- a/src/checks/eslintConfigIsValid.ts
+++ b/src/checks/eslintConfigIsValid.ts
@@ -10,14 +10,14 @@ export const title = 'ESLint config is latest version';
 
 export default async function eslintConfigIsValid() {
   const { stdout: remoteVersion } = await execaCommand(
-    'npm show @upleveled/eslint-config-upleveled version',
+    'npm show eslint-config-upleveled version',
   );
 
   let localVersion;
 
   try {
     const eslintConfigPackageJsonPath = require.resolve(
-      '@upleveled/eslint-config-upleveled/package.json',
+      'eslint-config-upleveled/package.json',
     );
 
     localVersion = JSON.parse(
@@ -27,14 +27,14 @@ export default async function eslintConfigIsValid() {
 
   if (typeof localVersion === 'undefined') {
     throw new Error(
-      `The UpLeveled ESLint config has not been installed. Please install using the instructions on https://www.npmjs.com/package/@upleveled/eslint-config-upleveled
+      `The UpLeveled ESLint config has not been installed. Please install using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,
     );
   }
 
   if (semver.gt(remoteVersion, localVersion)) {
     throw new Error(
-      `Your current version of the UpLeveled ESLint config (${localVersion}) is out of date. The latest version is ${remoteVersion}. Upgrade by running all lines of the install instructions on https://www.npmjs.com/package/@upleveled/eslint-config-upleveled`,
+      `Your current version of the UpLeveled ESLint config (${localVersion}) is out of date. The latest version is ${remoteVersion}. Upgrade by running all lines of the install instructions on https://www.npmjs.com/package/eslint-config-upleveled`,
     );
   }
 
@@ -51,14 +51,14 @@ const config = {
 module.exports = config;`;
   } catch (err) {
     throw new Error(
-      `Error reading your .eslintrc.cjs file. Please reinstall the config using the instructions on https://www.npmjs.com/package/@upleveled/eslint-config-upleveled
+      `Error reading your .eslintrc.cjs file. Please reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,
     );
   }
 
   if (!eslintConfigMatches) {
     throw new Error(
-      `Your ESLint config file .eslintrc.cjs does not match the configuration file template. Please reinstall the config using the instructions on https://www.npmjs.com/package/@upleveled/eslint-config-upleveled
+      `Your ESLint config file .eslintrc.cjs does not match the configuration file template. Please reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,
     );
   }

--- a/src/checks/eslintConfigIsValid.ts
+++ b/src/checks/eslintConfigIsValid.ts
@@ -45,7 +45,7 @@ export default async function eslintConfigIsValid() {
       (await fs.readFile('./.eslintrc.cjs', 'utf-8')).trim() ===
       `/** @type {import('@typescript-eslint/utils').TSESLint.Linter.Config} */
 const config = {
-  extends: ['@upleveled/upleveled'],
+  extends: ['upleveled'],
 };
 
 module.exports = config;`;

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -77,7 +77,7 @@ export default async function noUnusedAndMissingDependencies() {
 
     if (missingDependenciesStdout) {
       /**
-       * Temporary workaround to filter out @upleveled/eslint-config-upleveled peer dependencies
+       * Temporary workaround to filter out eslint-config-upleveled peer dependencies
        * not listed in `package.json`, which are flagged as missing dependencies by depcheck
        *
        * TODO: Remove this variable once this depcheck issue is fixed:
@@ -92,7 +92,7 @@ export default async function noUnusedAndMissingDependencies() {
               '@next/eslint-plugin-next',
               '@typescript-eslint/eslint-plugin',
               '@typescript-eslint/parser',
-              '@upleveled/eslint-plugin-upleveled',
+              'eslint-plugin-upleveled',
               'eslint-config-react-app',
               'eslint-import-resolver-typescript',
               'eslint-plugin-import',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5210,10 +5210,10 @@ eslint-config-react-app@^5.2.1:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-config-upleveled@4.0.12:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/eslint-config-upleveled/-/eslint-config-upleveled-4.0.12.tgz#fe16b678702063e6c7b348d9c83e09a73c1885f8"
-  integrity sha512-kRUjvxlYkC41oaj1a5E3uYjKktSCdtzwF0RcMqJdc9SBKWzgpi6+kf1XZ1+Ad9R8q2tJjE4++NaEa33PhgIjhA==
+eslint-config-upleveled@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/eslint-config-upleveled/-/eslint-config-upleveled-4.0.13.tgz#1f3458fd956d373558090a6259d48b42a1be17fb"
+  integrity sha512-ORkHIqfJLotFmDn9k7V6d2HNRyBPk5Yz9jqVtPBNUkGBKlyVk/FG/wslsaZVkalsckkHbujDgxlM5G64wls9Zg==
 
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"


### PR DESCRIPTION
## Description

The Upleveled ESLint config package name has been changed from `@upleveled/eslint-config-upleveled` to `eslint-config-upleveled`. This PR updates the value in the validation check from `@upleveled/upleveled` to `upleveled` to align with the updated package name. This ensures that the correct package name is checked during the test. 