### PR TITLE
Add stylelint and config to list of exeptions

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -25,6 +25,10 @@ export default async function noUnusedAndMissingDependencies() {
     'babel-eslint',
     'eslint-config-next',
 
+    // Stylelint configuration
+    'stylelint',
+    'stylelint-config-upleveled',
+
     // Testing
     'babel-jest',
     'cypress',


### PR DESCRIPTION
the current version of preflight on react passing repo is failing with the new configuration due stylelint and stylelint-conifg:

```
➜  preflight-test-project-react-passing git:(add-stylelint) preflight
🚀 UpLeveled Preflight v1.23.7
✔ All changes committed to Git
✔ node_modules/ folder ignored in Git
✔ No extraneous files committed to Git
✔ No secrets committed to Git
✔ Use single package manager
✔ Project folder name matches correct format
⚠ No dependency problems
  ✖ No unused dependencies
    › Unused dependencies found:
      * stylelint
      * stylelint-config-upleveled

      Remove these dependencies by running the following command for each dependency:

      ‎  $ pnpm remove <dependency name here>

  ✔ No dependencies without types
✔ GitHub repo has deployed project link under About
✔ ESLint
✔ Prettier
✔ ESLint config is latest version
✔ Preflight is latest version
```

This PR addresses this issue by adding stylelint to the exception list