### PR TITLE
Enable corepack and add pnpm in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18.10-alpine3.15
 WORKDIR /preflight
 COPY ./docker/clone-and-preflight.js ./docker/package.json ./docker/pnpm-lock.yaml ./
+RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN pnpm install --frozen-lockfile
 RUN pnpm add --global @upleveled/preflight
 # Allow `git clone` in the script


### PR DESCRIPTION
This PR enables `corepack` and adds `pnpm` to the Dockerfile to address the failed build issues. This PR adds missing Dockerfile changes in  #379 

This PR addresses issues with the Docker build process by enabling Corepack and adding pnpm to the Dockerfile. The previous build failed with 
```
/bin/sh: pnpm: not found
```
This change should allow for successful Docker builds going forward, which was missed in #379 