### PR TITLE
Use sep instead of / (#390

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -53,7 +53,7 @@ export default async function noUnusedAndMissingDependencies() {
 
   try {
     await execaCommand(
-      `${preflightBinPath}${sep}depcheck --ignores="${ignoredPackagePatterns}"`,
+      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
     );
   } catch (error) {
     const { stdout } = error as { stdout: string };

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -1,3 +1,4 @@
+import { sep } from 'node:path';
 import { execaCommand } from 'execa';
 import commandExample from '../../util/commandExample';
 import preflightBinPath from '../../util/preflightBinPath';
@@ -52,7 +53,7 @@ export default async function noUnusedAndMissingDependencies() {
 
   try {
     await execaCommand(
-      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+      `${preflightBinPath}${sep}depcheck --ignores="${ignoredPackagePatterns}"`,
     );
   } catch (error) {
     const { stdout } = error as { stdout: string };
@@ -95,7 +96,7 @@ export default async function noUnusedAndMissingDependencies() {
         .split('\n')
         .filter((missingDependency) => {
           return !(
-            missingDependency.includes('./.eslintrc.cjs') &&
+            missingDependency.includes(`.${sep}.eslintrc.cjs`) &&
             [
               '@next/eslint-plugin-next',
               '@typescript-eslint/eslint-plugin',


### PR DESCRIPTION
The new ESLint output on Windows uses backslashes, which fails with our check against the literal forward slash in the Unused Dependencies check