### PR TITLE
Add Docker build and run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "analyze": "size-limit --why",
     "build": "tsdx build --format esm --target node",
     "docker-build": "docker build -t preflight .",
-    "docker-build-run": "pnpm docker-build-ts && docker build -t preflight . && docker run preflight",
+    "docker-build-run": "pnpm docker-build-ts && pnpm docker-build && pnpm docker-run",
     "docker-build-ts": "tsc --project docker/tsconfig.build.json",
     "docker-run": "docker run preflight",
     "postinstall": "patch-package",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsdx build --format esm --target node",
-    "build-docker-ts": "tsc --project docker/tsconfig.build.json",
+    "docker-build": "pnpm docker-build-ts && docker build -t preflight .",
+    "docker-build-run": "pnpm docker-build-ts && docker build -t preflight . && docker run preflight",
+    "docker-build-ts": "tsc --project docker/tsconfig.build.json",
+    "docker-run": "docker run preflight",
     "postinstall": "patch-package",
     "lint": "eslint . --max-warnings 0",
     "prepare": "pnpm build",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsdx build --format esm --target node",
-    "docker-build": "pnpm docker-build-ts && docker build -t preflight .",
+    "docker-build": "docker build -t preflight .",
     "docker-build-run": "pnpm docker-build-ts && docker build -t preflight . && docker run preflight",
     "docker-build-ts": "tsc --project docker/tsconfig.build.json",
     "docker-run": "docker run preflight",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsdx build --format esm --target node",
-    "docker-build": "docker build -t preflight .",
+    "docker-build": "docker build --tag preflight .",
     "docker-build-run": "pnpm docker-build-ts && pnpm docker-build && pnpm docker-run",
     "docker-build-ts": "tsc --project docker/tsconfig.build.json",
     "docker-run": "docker run preflight",


### PR DESCRIPTION
## Description
This PR adds three new scripts to the package.json file:
- `docker-build`: Build a Docker image 
- `docker-run`: Run the Docker image
- `docker-build-run`: Build a Docker image and immediately run the Docker image

This makes building and running a Docker image easier, simplifying the deployment process.