### PR TITLE
Pass message property in Algolia error message

### DIFF
--- a/src/checks/eslintConfigIsValid.ts
+++ b/src/checks/eslintConfigIsValid.ts
@@ -23,7 +23,7 @@ export default async function eslintConfigIsValid() {
     localVersion = JSON.parse(
       await fs.readFile(eslintConfigPackageJsonPath, 'utf-8'),
     ).version;
-  } catch (err) {}
+  } catch (error) {}
 
   if (typeof localVersion === 'undefined') {
     throw new Error(
@@ -50,7 +50,7 @@ const config = {
 };
 
 module.exports = config;`;
-  } catch (err) {
+  } catch (error) {
     throw new Error(
       `Error reading your .eslintrc.cjs file - please delete the file if it exists and reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,

--- a/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
+++ b/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
@@ -74,7 +74,7 @@ export default async function noDependenciesWithoutTypes() {
         // Show dependency name if Algolia's `index.getObject()` throws with an
         // error message (such as the error message "ObjectID does not exist"
         // when a package cannot be found in the index)
-        throw new Error(`Algolia error for \`${dependency}\`: ${err}`);
+        throw new Error(`Algolia error for \`${dependency}\`: ${err.message}`);
       }
 
       const definitelyTypedPackageName = results.types?.definitelyTyped;

--- a/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
+++ b/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
@@ -51,13 +51,13 @@ export default async function noDependenciesWithoutTypes() {
         if ('types' in modulePackageJson || 'typings' in modulePackageJson) {
           return filteredDependencies;
         }
-      } catch (err) {}
+      } catch (error) {}
 
       let indexDTsPath;
 
       try {
         indexDTsPath = require.resolve(`${dependency}/index.d.ts`);
-      } catch (err) {}
+      } catch (error) {}
 
       // If the index.d.ts file exists inside the module's directory, bail out
       if (indexDTsPath && existsSync(indexDTsPath)) {
@@ -70,12 +70,12 @@ export default async function noDependenciesWithoutTypes() {
         results = await index.getObject<AlgoliaObj>(dependency, {
           attributesToRetrieve: ['types'],
         });
-      } catch (error: any) {
+      } catch (error) {
         // Show dependency name if Algolia's `index.getObject()` throws with an
         // error message (such as the error message "ObjectID does not exist"
         // when a package cannot be found in the index)
         throw new Error(
-          `Algolia error for \`${dependency}\`: ${error.message}`,
+          `Algolia error for \`${dependency}\`: ${(error as Error).message}`,
         );
       }
 

--- a/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
+++ b/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
@@ -70,11 +70,13 @@ export default async function noDependenciesWithoutTypes() {
         results = await index.getObject<AlgoliaObj>(dependency, {
           attributesToRetrieve: ['types'],
         });
-      } catch (err) {
+      } catch (error: any) {
         // Show dependency name if Algolia's `index.getObject()` throws with an
         // error message (such as the error message "ObjectID does not exist"
         // when a package cannot be found in the index)
-        throw new Error(`Algolia error for \`${dependency}\`: ${err.message}`);
+        throw new Error(
+          `Algolia error for \`${dependency}\`: ${error.message}`,
+        );
       }
 
       const definitelyTypedPackageName = results.types?.definitelyTyped;

--- a/src/checks/stylelintConfigIsValid.ts
+++ b/src/checks/stylelintConfigIsValid.ts
@@ -24,7 +24,7 @@ export default async function stylelintConfigIsValid() {
     localVersion = JSON.parse(
       await fs.readFile(stylelintConfigPackageJsonPath, 'utf-8'),
     ).version;
-  } catch (err) {}
+  } catch (error) {}
 
   if (typeof localVersion === 'undefined') {
     throw new Error(
@@ -52,7 +52,7 @@ const config = {
 };
 
 module.exports = config;`;
-  } catch (err) {
+  } catch (error) {
     throw new Error(
       `Error reading your stylelint.config.cjs file - please delete the file if it exists and reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,


### PR DESCRIPTION
Current behaviour:
```
 ✖ No dependencies without types
    › Algolia error for `@apollo/experimental-nextjs-app-support`: [object Object]
```
Expected result:
```
 ✖ No dependencies without types
    › Algolia error for `@apollo/experimental-nextjs-app-support`: ObjectID does not exist
```
