### PR TITLE
Add workaround for missing depcheck parser config

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -58,7 +58,23 @@ export default async function noUnusedAndMissingDependencies() {
 
   try {
     await execaCommand(
-      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --parsers="${
+        // TODO: Remove this once depcheck PR is published:
+        // https://github.com/depcheck/depcheck/pull/773#issuecomment-1649749599
+        [
+          '**/*.js:jsx',
+          '**/*.mjs:jsx',
+          '**/*.cjs:jsx',
+          '**/*.jsx:jsx',
+          '**/*.graphql:graphql',
+          '**/*.cts:typescript',
+          '**/*.mts:typescript',
+          '**/*.ts:typescript',
+          '**/*.tsx:typescript',
+          '**/*.sass:sass',
+          '**/*.scss:sass',
+        ].join(',')
+      }"`,
     );
   } catch (error) {
     const { stdout } = error as { stdout: string };


### PR DESCRIPTION
Closes #417

The `.mjs` and `.cjs` parser configuration has been implemented in https://github.com/depcheck/depcheck/pull/773, but it has not yet been published and may not be published for some time.

In the meantime, configure this directly in the Preflight `depcheck` command

TODO: Remove this once the `depcheck` PR is published:

- https://github.com/depcheck/depcheck/pull/773#issuecomment-164974959