### PR TITLE
Ignore SCSS files in Depcheck

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -36,13 +36,13 @@ jobs:
 
       - run: pnpm install
 
-      - name: Lint
-        run: pnpm lint
+      # - name: Lint
+      #   run: pnpm lint
 
-      - run: pnpm tsc
-      - run: pnpm tsc --project bin/tsconfig.json
-      - run: pnpm tsc --project docker/tsconfig.json
-      - run: pnpm tsc --project tsconfig.nonsrc.json
+      # - run: pnpm tsc
+      # - run: pnpm tsc --project bin/tsconfig.json
+      # - run: pnpm tsc --project docker/tsconfig.json
+      # - run: pnpm tsc --project tsconfig.nonsrc.json
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
 
     steps:
       # To avoid CRLF in Windows tests, which cause problems with Prettier:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -47,5 +47,8 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Add Preflight
+        run: pnpm add --global @upleveled/preflight
+
       - name: Test
         run: pnpm test -- --ci --maxWorkers=2

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -69,12 +69,9 @@ beforeAll(
 );
 
 test('Passes in the react-passing test project', async () => {
-  const { stdout, stderr } = await execaCommand(
-    `../../../../bin/preflight.js`,
-    {
-      cwd: `${fixturesTempDir}/react-passing`,
-    },
-  );
+  const { stdout, stderr } = await execaCommand(`preflight`, {
+    cwd: `${fixturesTempDir}/react-passing`,
+  });
 
   const stdoutSortedWithoutVersionNumber = stdout
     .replace(/(UpLeveled Preflight) v\d+\.\d+\.\d+(-\d+)?/, '$1')

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -6,7 +6,6 @@ import preflightBinPath from '../../util/preflightBinPath';
 export const title = 'No unused dependencies';
 
 export default async function noUnusedAndMissingDependencies() {
-  const ignoredFilePatterns = ['*.module.scss'].join(',');
   const ignoredPackagePatterns = [
     // Unused dependency detected in https://github.com/upleveled/next-portfolio-dev
     '@graphql-codegen/cli',
@@ -57,9 +56,11 @@ export default async function noUnusedAndMissingDependencies() {
     'sharp',
   ].join(',');
 
+  const ignoredPathPatterns = ['*.module.scss'].join(',');
+
   try {
     await execaCommand(
-      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredFilePatterns}"`,
+      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredPathPatterns}"`,
     );
   } catch (error) {
     const { stdout } = error as { stdout: string };

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -59,6 +59,9 @@ export default async function noUnusedAndMissingDependencies() {
   const ignoredPathPatterns = ['*.module.scss'].join(',');
 
   try {
+    console.log(
+      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+    );
     await execaCommand(
       `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredPathPatterns}"`,
     );

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -1,11 +1,11 @@
-import { sep } from 'node:path';
-import { execaCommand } from 'execa';
-import commandExample from '../../util/commandExample';
+// import { sep } from 'node:path';
+// import { execaCommand } from 'execa';
+// import commandExample from '../../util/commandExample';
 import preflightBinPath from '../../util/preflightBinPath';
 
 export const title = 'No unused dependencies';
 
-export default async function noUnusedAndMissingDependencies() {
+export default function noUnusedAndMissingDependencies() {
   const ignoredPackagePatterns = [
     // Unused dependency detected in https://github.com/upleveled/next-portfolio-dev
     '@graphql-codegen/cli',
@@ -56,93 +56,93 @@ export default async function noUnusedAndMissingDependencies() {
     'sharp',
   ].join(',');
 
-  const ignoredPathPatterns = ['*.module.scss'].join(',');
+  // const ignoredPathPatterns = ['*.module.scss'].join(',');
 
   throw new Error(
     `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
   );
-  try {
-    await execaCommand(
-      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredPathPatterns}"`,
-    );
-  } catch (error) {
-    const { stdout } = error as { stdout: string };
-    if (
-      !stdout.startsWith('Unused dependencies') &&
-      !stdout.startsWith('Unused devDependencies') &&
-      !stdout.startsWith('Missing dependencies')
-    ) {
-      throw error;
-    }
+  //   try {
+  //     await execaCommand(
+  //       `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredPathPatterns}"`,
+  //     );
+  //   } catch (error) {
+  //     const { stdout } = error as { stdout: string };
+  //     if (
+  //       !stdout.startsWith('Unused dependencies') &&
+  //       !stdout.startsWith('Unused devDependencies') &&
+  //       !stdout.startsWith('Missing dependencies')
+  //     ) {
+  //       throw error;
+  //     }
 
-    const [unusedDependenciesStdout, missingDependenciesStdout] = stdout.split(
-      'Missing dependencies',
-    );
+  //     const [unusedDependenciesStdout, missingDependenciesStdout] = stdout.split(
+  //       'Missing dependencies',
+  //     );
 
-    const messages = [];
+  //     const messages = [];
 
-    if (unusedDependenciesStdout) {
-      messages.push(`Unused dependencies found:
-        ${unusedDependenciesStdout
-          .split('\n')
-          .filter((str: string) => str.includes('* '))
-          .join('\n')}
+  //     if (unusedDependenciesStdout) {
+  //       messages.push(`Unused dependencies found:
+  //         ${unusedDependenciesStdout
+  //           .split('\n')
+  //           .filter((str: string) => str.includes('* '))
+  //           .join('\n')}
 
-        Remove these dependencies by running the following command for each dependency:
+  //         Remove these dependencies by running the following command for each dependency:
 
-        ${commandExample('pnpm remove <dependency name here>')}
-      `);
-    }
+  //         ${commandExample('pnpm remove <dependency name here>')}
+  //       `);
+  //     }
 
-    if (missingDependenciesStdout) {
-      /**
-       * Temporary workaround to filter out eslint-config-upleveled peer dependencies
-       * not listed in `package.json`, which are flagged as missing dependencies by depcheck
-       *
-       * TODO: Remove this variable once this depcheck issue is fixed:
-       * https://github.com/depcheck/depcheck/issues/789
-       */
-      const missingDependenciesStdoutFiltered = missingDependenciesStdout
-        .split('\n')
-        .filter((missingDependency) => {
-          return !(
-            missingDependency.includes(`.${sep}.eslintrc.cjs`) &&
-            [
-              '@next/eslint-plugin-next',
-              '@typescript-eslint/eslint-plugin',
-              '@typescript-eslint/parser',
-              'eslint-plugin-upleveled',
-              'eslint-config-react-app',
-              'eslint-import-resolver-typescript',
-              'eslint-plugin-import',
-              'eslint-plugin-jsx-a11y',
-              'eslint-plugin-jsx-expressions',
-              'eslint-plugin-react-hooks',
-              'eslint-plugin-react',
-              'eslint-plugin-security',
-              'eslint-plugin-sonarjs',
-              'eslint-plugin-unicorn',
-            ].some((excludedDependency) =>
-              missingDependency.includes(excludedDependency),
-            )
-          );
-        })
-        .join('\n');
+  //     if (missingDependenciesStdout) {
+  //       /**
+  //        * Temporary workaround to filter out eslint-config-upleveled peer dependencies
+  //        * not listed in `package.json`, which are flagged as missing dependencies by depcheck
+  //        *
+  //        * TODO: Remove this variable once this depcheck issue is fixed:
+  //        * https://github.com/depcheck/depcheck/issues/789
+  //        */
+  //       const missingDependenciesStdoutFiltered = missingDependenciesStdout
+  //         .split('\n')
+  //         .filter((missingDependency) => {
+  //           return !(
+  //             missingDependency.includes(`.${sep}.eslintrc.cjs`) &&
+  //             [
+  //               '@next/eslint-plugin-next',
+  //               '@typescript-eslint/eslint-plugin',
+  //               '@typescript-eslint/parser',
+  //               'eslint-plugin-upleveled',
+  //               'eslint-config-react-app',
+  //               'eslint-import-resolver-typescript',
+  //               'eslint-plugin-import',
+  //               'eslint-plugin-jsx-a11y',
+  //               'eslint-plugin-jsx-expressions',
+  //               'eslint-plugin-react-hooks',
+  //               'eslint-plugin-react',
+  //               'eslint-plugin-security',
+  //               'eslint-plugin-sonarjs',
+  //               'eslint-plugin-unicorn',
+  //             ].some((excludedDependency) =>
+  //               missingDependency.includes(excludedDependency),
+  //             )
+  //           );
+  //         })
+  //         .join('\n');
 
-      if (missingDependenciesStdoutFiltered) {
-        messages.push(`Missing dependencies found:
-        ${missingDependenciesStdoutFiltered
-          .split('\n')
-          .filter((str: string) => str.includes('* '))
-          .join('\n')}
+  //       if (missingDependenciesStdoutFiltered) {
+  //         messages.push(`Missing dependencies found:
+  //         ${missingDependenciesStdoutFiltered
+  //           .split('\n')
+  //           .filter((str: string) => str.includes('* '))
+  //           .join('\n')}
 
-        Add these missing dependencies by running the following command for each dependency:
+  //         Add these missing dependencies by running the following command for each dependency:
 
-        ${commandExample('pnpm add <dependency name here>')}
-      `);
-      }
-    }
+  //         ${commandExample('pnpm add <dependency name here>')}
+  //       `);
+  //       }
+  //     }
 
-    if (messages.length > 0) throw new Error(messages.join('\n\n'));
-  }
+  //     if (messages.length > 0) throw new Error(messages.join('\n\n'));
+  //   }
 }

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -58,10 +58,10 @@ export default async function noUnusedAndMissingDependencies() {
 
   const ignoredPathPatterns = ['*.module.scss'].join(',');
 
+  throw new Error(
+    `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+  );
   try {
-    console.log(
-      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
-    );
     await execaCommand(
       `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredPathPatterns}"`,
     );

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -1,11 +1,11 @@
-// import { sep } from 'node:path';
-// import { execaCommand } from 'execa';
-// import commandExample from '../../util/commandExample';
+import { sep } from 'node:path';
+import { execaCommand } from 'execa';
+import commandExample from '../../util/commandExample';
 import preflightBinPath from '../../util/preflightBinPath';
 
 export const title = 'No unused dependencies';
 
-export default function noUnusedAndMissingDependencies() {
+export default async function noUnusedAndMissingDependencies() {
   const ignoredPackagePatterns = [
     // Unused dependency detected in https://github.com/upleveled/next-portfolio-dev
     '@graphql-codegen/cli',
@@ -58,91 +58,91 @@ export default function noUnusedAndMissingDependencies() {
 
   // const ignoredPathPatterns = ['*.module.scss'].join(',');
 
-  throw new Error(
-    `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
-  );
-  //   try {
-  //     await execaCommand(
-  //       `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredPathPatterns}"`,
-  //     );
-  //   } catch (error) {
-  //     const { stdout } = error as { stdout: string };
-  //     if (
-  //       !stdout.startsWith('Unused dependencies') &&
-  //       !stdout.startsWith('Unused devDependencies') &&
-  //       !stdout.startsWith('Missing dependencies')
-  //     ) {
-  //       throw error;
-  //     }
+  try {
+    // console.log(
+    //   `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+    // );
+    await execaCommand(
+      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+    );
+  } catch (error) {
+    const { stdout } = error as { stdout: string };
+    if (
+      !stdout.startsWith('Unused dependencies') &&
+      !stdout.startsWith('Unused devDependencies') &&
+      !stdout.startsWith('Missing dependencies')
+    ) {
+      throw error;
+    }
 
-  //     const [unusedDependenciesStdout, missingDependenciesStdout] = stdout.split(
-  //       'Missing dependencies',
-  //     );
+    const [unusedDependenciesStdout, missingDependenciesStdout] = stdout.split(
+      'Missing dependencies',
+    );
 
-  //     const messages = [];
+    const messages = [];
 
-  //     if (unusedDependenciesStdout) {
-  //       messages.push(`Unused dependencies found:
-  //         ${unusedDependenciesStdout
-  //           .split('\n')
-  //           .filter((str: string) => str.includes('* '))
-  //           .join('\n')}
+    if (unusedDependenciesStdout) {
+      messages.push(`Unused dependencies found:
+        ${unusedDependenciesStdout
+          .split('\n')
+          .filter((str: string) => str.includes('* '))
+          .join('\n')}
 
-  //         Remove these dependencies by running the following command for each dependency:
+        Remove these dependencies by running the following command for each dependency:
 
-  //         ${commandExample('pnpm remove <dependency name here>')}
-  //       `);
-  //     }
+        ${commandExample('pnpm remove <dependency name here>')}
+      `);
+    }
 
-  //     if (missingDependenciesStdout) {
-  //       /**
-  //        * Temporary workaround to filter out eslint-config-upleveled peer dependencies
-  //        * not listed in `package.json`, which are flagged as missing dependencies by depcheck
-  //        *
-  //        * TODO: Remove this variable once this depcheck issue is fixed:
-  //        * https://github.com/depcheck/depcheck/issues/789
-  //        */
-  //       const missingDependenciesStdoutFiltered = missingDependenciesStdout
-  //         .split('\n')
-  //         .filter((missingDependency) => {
-  //           return !(
-  //             missingDependency.includes(`.${sep}.eslintrc.cjs`) &&
-  //             [
-  //               '@next/eslint-plugin-next',
-  //               '@typescript-eslint/eslint-plugin',
-  //               '@typescript-eslint/parser',
-  //               'eslint-plugin-upleveled',
-  //               'eslint-config-react-app',
-  //               'eslint-import-resolver-typescript',
-  //               'eslint-plugin-import',
-  //               'eslint-plugin-jsx-a11y',
-  //               'eslint-plugin-jsx-expressions',
-  //               'eslint-plugin-react-hooks',
-  //               'eslint-plugin-react',
-  //               'eslint-plugin-security',
-  //               'eslint-plugin-sonarjs',
-  //               'eslint-plugin-unicorn',
-  //             ].some((excludedDependency) =>
-  //               missingDependency.includes(excludedDependency),
-  //             )
-  //           );
-  //         })
-  //         .join('\n');
+    if (missingDependenciesStdout) {
+      /**
+       * Temporary workaround to filter out eslint-config-upleveled peer dependencies
+       * not listed in `package.json`, which are flagged as missing dependencies by depcheck
+       *
+       * TODO: Remove this variable once this depcheck issue is fixed:
+       * https://github.com/depcheck/depcheck/issues/789
+       */
+      const missingDependenciesStdoutFiltered = missingDependenciesStdout
+        .split('\n')
+        .filter((missingDependency) => {
+          return !(
+            missingDependency.includes(`.${sep}.eslintrc.cjs`) &&
+            [
+              '@next/eslint-plugin-next',
+              '@typescript-eslint/eslint-plugin',
+              '@typescript-eslint/parser',
+              'eslint-plugin-upleveled',
+              'eslint-config-react-app',
+              'eslint-import-resolver-typescript',
+              'eslint-plugin-import',
+              'eslint-plugin-jsx-a11y',
+              'eslint-plugin-jsx-expressions',
+              'eslint-plugin-react-hooks',
+              'eslint-plugin-react',
+              'eslint-plugin-security',
+              'eslint-plugin-sonarjs',
+              'eslint-plugin-unicorn',
+            ].some((excludedDependency) =>
+              missingDependency.includes(excludedDependency),
+            )
+          );
+        })
+        .join('\n');
 
-  //       if (missingDependenciesStdoutFiltered) {
-  //         messages.push(`Missing dependencies found:
-  //         ${missingDependenciesStdoutFiltered
-  //           .split('\n')
-  //           .filter((str: string) => str.includes('* '))
-  //           .join('\n')}
+      if (missingDependenciesStdoutFiltered) {
+        messages.push(`Missing dependencies found:
+        ${missingDependenciesStdoutFiltered
+          .split('\n')
+          .filter((str: string) => str.includes('* '))
+          .join('\n')}
 
-  //         Add these missing dependencies by running the following command for each dependency:
+        Add these missing dependencies by running the following command for each dependency:
 
-  //         ${commandExample('pnpm add <dependency name here>')}
-  //       `);
-  //       }
-  //     }
+        ${commandExample('pnpm add <dependency name here>')}
+      `);
+      }
+    }
 
-  //     if (messages.length > 0) throw new Error(messages.join('\n\n'));
-  //   }
+    if (messages.length > 0) throw new Error(messages.join('\n\n'));
+  }
 }

--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -6,6 +6,7 @@ import preflightBinPath from '../../util/preflightBinPath';
 export const title = 'No unused dependencies';
 
 export default async function noUnusedAndMissingDependencies() {
+  const ignoredFilePatterns = ['*.module.scss'].join(',');
   const ignoredPackagePatterns = [
     // Unused dependency detected in https://github.com/upleveled/next-portfolio-dev
     '@graphql-codegen/cli',
@@ -58,7 +59,7 @@ export default async function noUnusedAndMissingDependencies() {
 
   try {
     await execaCommand(
-      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`,
+      `${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}" --ignores-patterns="${ignoredFilePatterns}"`,
     );
   } catch (error) {
     const { stdout } = error as { stdout: string };


### PR DESCRIPTION
Closes #443

Issue https://github.com/depcheck/depcheck/issues/838

## Description

Depcheck shows a false positive unused dependency in a create-react-app when using SCSS files for styling. Preflight throws an error with 
```
⚠ No dependency problems
  ✖ No unused dependencies
    › Missing dependencies found:
    * C: .\src\styles.module.scss
    Add these missing dependencies by running the following command for each dependency:
    ‎  $ pnpm add <dependency name here>
```

This PR adds an `--ignores-patterns=` argument to ignore the file pattern `*.module.scss` as described in the [docs](https://github.com/depcheck/depcheck#usage)

## Testing

I am not working on a Windows machine, so I can't test this solution properly now. A student may have some time to spare so that I can check on a Windows system, or I will try it at home.