### PR TITLE
Switch Docker Node.js v18 to LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:lts-alpine
 
 WORKDIR /preflight
 


### PR DESCRIPTION
LTS is currently v18, so this should actually not cause any change until v20 becomes LTS later this year