### PR TITLE
Switch config files from .cjs to .mjs

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -22,6 +22,9 @@ export default async function noUnusedAndMissingDependencies() {
     // Sass (eg. in create-react-app)
     'sass',
 
+    // Prettier plugins
+    'prettier-plugin-*',
+
     // ESLint configuration
     'babel-eslint',
     'eslint-config-next',

--- a/src/checks/prettier.ts
+++ b/src/checks/prettier.ts
@@ -13,7 +13,7 @@ export default async function prettierCheck() {
         '..',
         'node_modules',
         '.bin',
-      )}/prettier --list-different **/*.{js,jsx,ts,jsx} --ignore-path .eslintignore --config prettier.config.mjs --end-of-line auto`,
+      )}/prettier --list-different **/*.{js,jsx,ts,jsx} --ignore-path .eslintignore --end-of-line auto`,
     );
   } catch (error) {
     const { stdout, stderr } = error as { stdout: string; stderr: string };
@@ -54,8 +54,6 @@ export default async function prettierCheck() {
           ${unformattedFiles.join('\n')}
 
           For each of the files above, open the file in your editor and save the file. This will format the file with Prettier, which will cause changes to appear in Git.
-
-          In some very uncommon cases (this probably doesn't apply to you), the mismatch may come from inconsistent end of line characters. Read more here: https://github.com/upleveled/answers/issues/31
         `,
       );
     }

--- a/src/checks/prettier.ts
+++ b/src/checks/prettier.ts
@@ -8,7 +8,7 @@ export const title = 'Prettier';
 export default async function prettierCheck() {
   try {
     await execaCommand(
-      `../node_modules/.bin/prettier --list-different ${process.cwd()}/**/*.{js,jsx,ts,jsx} --ignore-path ${process.cwd()}/.eslintignore --config ${process.cwd()}/prettier.config.cjs --end-of-line auto`,
+      `../node_modules/.bin/prettier --list-different ${process.cwd()}/**/*.{js,jsx,ts,jsx} --ignore-path ${process.cwd()}/.eslintignore --config ${process.cwd()}/prettier.config.mjs --end-of-line auto`,
       { cwd: dirname(fileURLToPath(import.meta.url)) },
     );
   } catch (error) {

--- a/src/checks/prettier.ts
+++ b/src/checks/prettier.ts
@@ -1,4 +1,4 @@
-import { dirname, relative, sep } from 'node:path';
+import { dirname, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execaCommand } from 'execa';
 import normalizeNewline from '../util/normalizeNewline';
@@ -8,7 +8,12 @@ export const title = 'Prettier';
 export default async function prettierCheck() {
   try {
     await execaCommand(
-      `../node_modules/.bin/prettier --list-different ${process.cwd()}/**/*.{js,jsx,ts,jsx} --ignore-path ${process.cwd()}/.eslintignore --config ${process.cwd()}/prettier.config.mjs --end-of-line auto`,
+      `${resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        '..',
+        'node_modules',
+        '.bin',
+      )}/prettier --list-different **/*.{js,jsx,ts,jsx} --ignore-path .eslintignore --config prettier.config.mjs --end-of-line auto`,
       { cwd: dirname(fileURLToPath(import.meta.url)) },
     );
   } catch (error) {

--- a/src/checks/prettier.ts
+++ b/src/checks/prettier.ts
@@ -14,7 +14,6 @@ export default async function prettierCheck() {
         'node_modules',
         '.bin',
       )}/prettier --list-different **/*.{js,jsx,ts,jsx} --ignore-path .eslintignore --config prettier.config.mjs --end-of-line auto`,
-      { cwd: dirname(fileURLToPath(import.meta.url)) },
     );
   } catch (error) {
     const { stdout, stderr } = error as { stdout: string; stderr: string };

--- a/src/checks/stylelintConfigIsValid.ts
+++ b/src/checks/stylelintConfigIsValid.ts
@@ -45,23 +45,23 @@ export default async function stylelintConfigIsValid() {
 
   try {
     stylelintConfigMatches =
-      (await fs.readFile('./stylelint.config.cjs', 'utf-8')).trim() ===
+      (await fs.readFile('./stylelint.config.mjs', 'utf-8')).trim() ===
       `/** @type { import('stylelint').Config } */
 const config = {
   extends: ['stylelint-config-upleveled'],
 };
 
-module.exports = config;`;
+export default config;`;
   } catch (error) {
     throw new Error(
-      `Error reading your stylelint.config.cjs file - please delete the file if it exists and reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
+      `Error reading your stylelint.config.mjs file - please delete the file if it exists and reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,
     );
   }
 
   if (!stylelintConfigMatches) {
     throw new Error(
-      `Your stylelint.config.cjs file does not match the configuration file template - please delete the file and reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
+      `Your stylelint.config.mjs file does not match the configuration file template - please delete the file and reinstall the config using the instructions on https://www.npmjs.com/package/eslint-config-upleveled
       `,
     );
   }


### PR DESCRIPTION
Ref: https://github.com/upleveled/eslint-config-upleveled/pull/292

We switched our Prettier and Stylelint configs from `.cjs` (CommonJS) to `.mjs` (ESM) in the PR above, so we should update the config path here too.