### PR TITLE
Avoid ESLint path resolution errors on Windows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -49,12 +49,17 @@ jobs:
         working-directory: docker
 
       - name: Lint
+        if: runner.os != 'Windows'
         run: pnpm lint
 
       - run: pnpm tsc
+        if: runner.os != 'Windows'
       - run: pnpm tsc --project bin/tsconfig.json
+        if: runner.os != 'Windows'
       - run: pnpm tsc --project docker/tsconfig.json
+        if: runner.os != 'Windows'
       - run: pnpm tsc --project tsconfig.nonsrc.json
+        if: runner.os != 'Windows'
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -45,6 +45,7 @@ jobs:
 
       - run: pnpm install
       - run: pnpm install
+        if: runner.os != 'Windows'
         working-directory: docker
 
       - name: Lint

--- a/__tests__/__snapshots__/e2e.test.ts.snap
+++ b/__tests__/__snapshots__/e2e.test.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Passes in the next-js-passing test project 1`] = `
+"🚀 UpLeveled Preflight
+[32m[COMPLETED][39m All changes committed to Git
+[32m[COMPLETED][39m ESLint
+[32m[COMPLETED][39m ESLint config is latest version
+[32m[COMPLETED][39m GitHub repo has deployed project link under About
+[32m[COMPLETED][39m Next.js project has sharp installed
+[32m[COMPLETED][39m No dependencies without types
+[32m[COMPLETED][39m No dependency problems
+[32m[COMPLETED][39m No extraneous files committed to Git
+[32m[COMPLETED][39m No secrets committed to Git
+[32m[COMPLETED][39m No unused dependencies
+[32m[COMPLETED][39m Preflight is latest version
+[32m[COMPLETED][39m Prettier
+[32m[COMPLETED][39m Project folder name matches correct format
+[32m[COMPLETED][39m Stylelint
+[32m[COMPLETED][39m Stylelint config is latest version
+[32m[COMPLETED][39m Use single package manager
+[32m[COMPLETED][39m node_modules/ folder ignored in Git
+[33m[STARTED][39m All changes committed to Git
+[33m[STARTED][39m ESLint
+[33m[STARTED][39m ESLint config is latest version
+[33m[STARTED][39m GitHub repo has deployed project link under About
+[33m[STARTED][39m Next.js project has sharp installed
+[33m[STARTED][39m No dependencies without types
+[33m[STARTED][39m No dependency problems
+[33m[STARTED][39m No extraneous files committed to Git
+[33m[STARTED][39m No secrets committed to Git
+[33m[STARTED][39m No unused dependencies
+[33m[STARTED][39m Preflight is latest version
+[33m[STARTED][39m Prettier
+[33m[STARTED][39m Project folder name matches correct format
+[33m[STARTED][39m Stylelint
+[33m[STARTED][39m Stylelint config is latest version
+[33m[STARTED][39m Use single package manager
+[33m[STARTED][39m node_modules/ folder ignored in Git"
+`;
+
+exports[`Passes in the next-js-passing test project 2`] = `""`;
+
 exports[`Passes in the react-passing test project 1`] = `
 "🚀 UpLeveled Preflight
 [32m[COMPLETED][39m All changes committed to Git

--- a/__tests__/__snapshots__/e2e.test.ts.snap
+++ b/__tests__/__snapshots__/e2e.test.ts.snap
@@ -1,45 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Passes in the next-js-passing test project 1`] = `
-"🚀 UpLeveled Preflight
-[32m[COMPLETED][39m All changes committed to Git
-[32m[COMPLETED][39m ESLint
-[32m[COMPLETED][39m ESLint config is latest version
-[32m[COMPLETED][39m GitHub repo has deployed project link under About
-[32m[COMPLETED][39m Next.js project has sharp installed
-[32m[COMPLETED][39m No dependencies without types
-[32m[COMPLETED][39m No dependency problems
-[32m[COMPLETED][39m No extraneous files committed to Git
-[32m[COMPLETED][39m No secrets committed to Git
-[32m[COMPLETED][39m No unused dependencies
-[32m[COMPLETED][39m Preflight is latest version
-[32m[COMPLETED][39m Prettier
-[32m[COMPLETED][39m Project folder name matches correct format
-[32m[COMPLETED][39m Stylelint
-[32m[COMPLETED][39m Stylelint config is latest version
-[32m[COMPLETED][39m Use single package manager
-[32m[COMPLETED][39m node_modules/ folder ignored in Git
-[33m[STARTED][39m All changes committed to Git
-[33m[STARTED][39m ESLint
-[33m[STARTED][39m ESLint config is latest version
-[33m[STARTED][39m GitHub repo has deployed project link under About
-[33m[STARTED][39m Next.js project has sharp installed
-[33m[STARTED][39m No dependencies without types
-[33m[STARTED][39m No dependency problems
-[33m[STARTED][39m No extraneous files committed to Git
-[33m[STARTED][39m No secrets committed to Git
-[33m[STARTED][39m No unused dependencies
-[33m[STARTED][39m Preflight is latest version
-[33m[STARTED][39m Prettier
-[33m[STARTED][39m Project folder name matches correct format
-[33m[STARTED][39m Stylelint
-[33m[STARTED][39m Stylelint config is latest version
-[33m[STARTED][39m Use single package manager
-[33m[STARTED][39m node_modules/ folder ignored in Git"
-`;
-
-exports[`Passes in the next-js-passing test project 2`] = `""`;
-
 exports[`Passes in the react-passing test project 1`] = `
 "🚀 UpLeveled Preflight
 [32m[COMPLETED][39m All changes committed to Git

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -37,12 +37,14 @@ const testRepos: Repo[] = [
             'git config user.email github-actions[bot]@users.noreply.github.com',
             'git config user.name github-actions[bot]',
             'git commit --all --message Remove\\ SafeSQL\\ for\\ Windows',
+            'pnpm setup',
             'pnpm add --global ../../../preflight',
           ]
         : [
             'pnpm install --frozen-lockfile',
             // Run project database migrations
             'pnpm migrate up',
+            'pnpm setup',
             'pnpm add --global ../../../preflight',
           ],
   },

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, expect, test } from '@jest/globals';
 import { execaCommand } from 'execa';
 import pMap from 'p-map';
 
-const tempDir = process.env.GITHUB_ACTIONS
+const fixturesTempDir = process.env.GITHUB_ACTIONS
   ? // Switch to `tmpdir()` on GitHub Actions to avoid
     // ESLint crashing with Windows paths over the 260
     // character MAX_PATH limit
@@ -14,7 +14,7 @@ const tempDir = process.env.GITHUB_ACTIONS
 
 function cloneRepoToFixtures(repoPath: string, fixtureDirName: string) {
   return execaCommand(
-    `git clone --depth 1 --single-branch --branch=main https://github.com/${repoPath}.git ${tempDir}/${fixtureDirName} --config core.autocrlf=input`,
+    `git clone --depth 1 --single-branch --branch=main https://github.com/${repoPath}.git ${fixturesTempDir}/${fixtureDirName} --config core.autocrlf=input`,
   );
 }
 
@@ -70,7 +70,7 @@ beforeAll(
           // `return pMap()` below
           return [
             await execaCommand('pnpm install --frozen-lockfile', {
-              cwd: `${tempDir}/${dirName}`,
+              cwd: `${fixturesTempDir}/${dirName}`,
             }),
           ];
         }
@@ -79,7 +79,7 @@ beforeAll(
           installCommands,
           (command) =>
             execaCommand(command, {
-              cwd: `${tempDir}/${dirName}`,
+              cwd: `${fixturesTempDir}/${dirName}`,
             }),
           { concurrency: 1 },
         );
@@ -107,7 +107,7 @@ test('Passes in the react-passing test project', async () => {
   const { stdout, stderr } = await execaCommand(
     `${process.cwd()}/bin/preflight.js`,
     {
-      cwd: `${tempDir}/react-passing`,
+      cwd: `${fixturesTempDir}/react-passing`,
     },
   );
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -87,8 +87,8 @@ beforeAll(
       { concurrency: 1 },
     );
   },
-  // 5 minute timeout for pnpm installation inside test repos
-  300000,
+  // 7.5 minute timeout for pnpm installation inside test repos
+  450000,
 );
 
 function sortStdoutAndStripVersionNumber(stdout: string) {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -117,7 +117,7 @@ test('Passes in the react-passing test project', async () => {
 
 test('Passes in the next-js-passing test project', async () => {
   const { stdout, stderr } = await execaCommand(
-    '../../../../bin/preflight.js',
+    `${process.cwd()}/bin/preflight.js`,
     {
       cwd: `${fixturesTempDir}/next-js-passing`,
     },

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -20,6 +20,14 @@ const testRepos: Repo[] = [
   {
     repoPath: 'upleveled/preflight-test-project-react-passing',
     dirName: 'react-passing',
+    installCommands:
+      process.platform === 'win32'
+        ? [
+            'pnpm config set node-linker hoisted --location project',
+            'pnpm install --frozen-lockfile',
+            'rm .npmrc',
+          ]
+        : ['pnpm install --frozen-lockfile'],
   },
   // {
   //   repoPath: 'upleveled/preflight-test-project-next-js-passing',
@@ -65,14 +73,9 @@ beforeAll(
           // Return array to keep return type uniform with
           // `return pMap()` below
           return [
-            await execaCommand(
-              process.platform === 'win32'
-                ? 'npm install'
-                : 'pnpm install --frozen-lockfile --shamefully-hoist',
-              {
-                cwd: `${fixturesTempDir}/${dirName}`,
-              },
-            ),
+            await execaCommand('pnpm install --frozen-lockfile', {
+              cwd: `${fixturesTempDir}/${dirName}`,
+            }),
           ];
         }
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -78,6 +78,7 @@ beforeAll(
               cwd: `${fixturesTempDir}/${dirName}`,
               env: {
                 PNPM_HOME: '/usr/local/bin',
+                SHELL: 'bash',
               },
             }),
           { concurrency: 1 },

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -106,7 +106,7 @@ function sortStdoutAndStripVersionNumber(stdout: string) {
 test('Passes in the react-passing test project', async () => {
   if (process.platform === 'win32') {
     const { stdout: stdout1 } = await execaCommand('dir', {
-      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\`,
+      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-plugin-jsx-expressions\\`,
     });
     console.log(stdout1);
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -106,7 +106,7 @@ function sortStdoutAndStripVersionNumber(stdout: string) {
 test('Passes in the react-passing test project', async () => {
   if (process.platform === 'win32') {
     const { stdout: stdout1 } = await execaCommand('dir', {
-      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@t_ygntojkrkqu3wjzv73xoodfpfe\\node_modules\\`,
+      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\`,
     });
     console.log(stdout1);
 
@@ -116,7 +116,7 @@ test('Passes in the react-passing test project', async () => {
     console.log(stdout2);
 
     const { stdout: stdout3 } = await execaCommand('type index.js', {
-      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@t_ygntojkrkqu3wjzv73xoodfpfe\\node_modules\\eslint-config-upleveled\\`,
+      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-config-upleveled\\`,
     });
     console.log(stdout3);
   }

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -37,11 +37,13 @@ const testRepos: Repo[] = [
             'git config user.email github-actions[bot]@users.noreply.github.com',
             'git config user.name github-actions[bot]',
             'git commit --all --message Remove\\ SafeSQL\\ for\\ Windows',
+            'pnpm add --global ../../../../',
           ]
         : [
             'pnpm install --frozen-lockfile',
             // Run project database migrations
             'pnpm migrate up',
+            'pnpm add --global ../../../../',
           ],
   },
 ];
@@ -108,12 +110,9 @@ test('Passes in the react-passing test project', async () => {
 }, 30000);
 
 test('Passes in the next-js-passing test project', async () => {
-  const { stdout, stderr } = await execaCommand(
-    `../../../../bin/preflight.js`,
-    {
-      cwd: `${fixturesTempDir}/next-js-passing`,
-    },
-  );
+  const { stdout, stderr } = await execaCommand('preflight', {
+    cwd: `${fixturesTempDir}/next-js-passing`,
+  });
 
   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -65,9 +65,14 @@ beforeAll(
           // Return array to keep return type uniform with
           // `return pMap()` below
           return [
-            await execaCommand('npm install', {
-              cwd: `${fixturesTempDir}/${dirName}`,
-            }),
+            await execaCommand(
+              process.platform === 'win32'
+                ? 'npm install'
+                : 'pnpm install --frozen-lockfile --shamefully-hoist',
+              {
+                cwd: `${fixturesTempDir}/${dirName}`,
+              },
+            ),
           ];
         }
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -65,12 +65,9 @@ beforeAll(
           // Return array to keep return type uniform with
           // `return pMap()` below
           return [
-            await execaCommand(
-              'pnpm install --frozen-lockfile --shamefully-hoist',
-              {
-                cwd: `${fixturesTempDir}/${dirName}`,
-              },
-            ),
+            await execaCommand('npm install', {
+              cwd: `${fixturesTempDir}/${dirName}`,
+            }),
           ];
         }
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -37,13 +37,13 @@ const testRepos: Repo[] = [
             'git config user.email github-actions[bot]@users.noreply.github.com',
             'git config user.name github-actions[bot]',
             'git commit --all --message Remove\\ SafeSQL\\ for\\ Windows',
-            'pnpm add --global ../../../../',
+            'pnpm add --global ../../../preflight',
           ]
         : [
             'pnpm install --frozen-lockfile',
             // Run project database migrations
             'pnpm migrate up',
-            'pnpm add --global ../../../../',
+            'pnpm add --global ../../../preflight',
           ],
   },
 ];

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -76,6 +76,9 @@ beforeAll(
           (command) =>
             execaCommand(command, {
               cwd: `${fixturesTempDir}/${dirName}`,
+              env: {
+                PNPM_HOME: '/usr/local/bin',
+              },
             }),
           { concurrency: 1 },
         );

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -21,33 +21,33 @@ const testRepos: Repo[] = [
     repoPath: 'upleveled/preflight-test-project-react-passing',
     dirName: 'react-passing',
   },
-  {
-    repoPath: 'upleveled/preflight-test-project-next-js-passing',
-    dirName: 'next-js-passing',
-    installCommands:
-      // libpg-query is not yet supported on Windows
-      // https://github.com/pganalyze/libpg_query/issues/44
-      process.platform === 'win32'
-        ? [
-            // `pnpm remove` also installs if node_modules doesn't
-            // exist (no need to run `pnpm install` as well)
-            'pnpm remove @ts-safeql/eslint-plugin libpg-query',
-            // Commit packages.json and pnpm-lock.yaml changes to
-            // avoid failing "All changes committed to Git" check
-            'git config user.email github-actions[bot]@users.noreply.github.com',
-            'git config user.name github-actions[bot]',
-            'git commit --all --message Remove\\ SafeSQL\\ for\\ Windows',
-            'pnpm setup',
-            'pnpm add --global ../../../preflight',
-          ]
-        : [
-            'pnpm install --frozen-lockfile',
-            // Run project database migrations
-            'pnpm migrate up',
-            'pnpm setup',
-            'pnpm add --global ../../../preflight',
-          ],
-  },
+  // {
+  //   repoPath: 'upleveled/preflight-test-project-next-js-passing',
+  //   dirName: 'next-js-passing',
+  //   installCommands:
+  //     // libpg-query is not yet supported on Windows
+  //     // https://github.com/pganalyze/libpg_query/issues/44
+  //     process.platform === 'win32'
+  //       ? [
+  //           // `pnpm remove` also installs if node_modules doesn't
+  //           // exist (no need to run `pnpm install` as well)
+  //           'pnpm remove @ts-safeql/eslint-plugin libpg-query',
+  //           // Commit packages.json and pnpm-lock.yaml changes to
+  //           // avoid failing "All changes committed to Git" check
+  //           'git config user.email github-actions[bot]@users.noreply.github.com',
+  //           'git config user.name github-actions[bot]',
+  //           'git commit --all --message Remove\\ SafeSQL\\ for\\ Windows',
+  //           // 'pnpm setup',
+  //           // 'pnpm add --global ../../../preflight',
+  //         ]
+  //       : [
+  //           'pnpm install --frozen-lockfile',
+  //           // Run project database migrations
+  //           'pnpm migrate up',
+  //           // 'pnpm setup',
+  //           // 'pnpm add --global ../../../preflight',
+  //         ],
+  // },
 ];
 
 beforeAll(
@@ -76,10 +76,10 @@ beforeAll(
           (command) =>
             execaCommand(command, {
               cwd: `${fixturesTempDir}/${dirName}`,
-              env: {
-                PNPM_HOME: '/usr/local/bin',
-                SHELL: 'bash',
-              },
+              // env: {
+              //   PNPM_HOME: '/usr/local/bin',
+              //   SHELL: 'bash',
+              // },
             }),
           { concurrency: 1 },
         );
@@ -104,8 +104,25 @@ function sortStdoutAndStripVersionNumber(stdout: string) {
 }
 
 test('Passes in the react-passing test project', async () => {
+  if (process.platform === 'win32') {
+    const { stdout: stdout1 } = await execaCommand('dir', {
+      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@t_ygntojkrkqu3wjzv73xoodfpfe\\node_modules\\`,
+    });
+    console.log(stdout1);
+
+    const { stdout: stdout2 } = await execaCommand('dir', {
+      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\`,
+    });
+    console.log(stdout2);
+
+    const { stdout: stdout3 } = await execaCommand('type index.js', {
+      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@t_ygntojkrkqu3wjzv73xoodfpfe\\node_modules\\eslint-config-upleveled\\`,
+    });
+    console.log(stdout3);
+  }
+
   const { stdout, stderr } = await execaCommand(
-    `../../../../bin/preflight.js`,
+    '../../../../bin/preflight.js',
     {
       cwd: `${fixturesTempDir}/react-passing`,
     },
@@ -115,11 +132,15 @@ test('Passes in the react-passing test project', async () => {
   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
 }, 30000);
 
-test('Passes in the next-js-passing test project', async () => {
-  const { stdout, stderr } = await execaCommand('preflight', {
-    cwd: `${fixturesTempDir}/next-js-passing`,
-  });
+// test('Passes in the next-js-passing test project', async () => {
 
-  expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
-  expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
-}, 45000);
+//   const { stdout, stderr } = await execaCommand(
+//     '../../../../bin/preflight.js',
+//     {
+//       cwd: `${fixturesTempDir}/next-js-passing`,
+//     },
+//   );
+
+//   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
+//   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
+// }, 45000);

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -1,12 +1,13 @@
+import { tmpdir } from 'node:os';
 import { beforeAll, expect, test } from '@jest/globals';
 import { execaCommand } from 'execa';
 import pMap from 'p-map';
 
-const fixturesTempDir = '__tests__/fixtures/__temp';
+const tempDir = tmpdir();
 
 function cloneRepoToFixtures(repoPath: string, fixtureDirName: string) {
   return execaCommand(
-    `git clone --depth 1 --single-branch --branch=main https://github.com/${repoPath}.git ${fixturesTempDir}/${fixtureDirName} --config core.autocrlf=input`,
+    `git clone --depth 1 --single-branch --branch=main https://github.com/${repoPath}.git ${tempDir}/${fixtureDirName} --config core.autocrlf=input`,
   );
 }
 
@@ -20,14 +21,14 @@ const testRepos: Repo[] = [
   {
     repoPath: 'upleveled/preflight-test-project-react-passing',
     dirName: 'react-passing',
-    installCommands:
-      process.platform === 'win32'
-        ? [
-            'pnpm config set node-linker hoisted --location project',
-            'pnpm install --frozen-lockfile',
-            'rm .npmrc',
-          ]
-        : ['pnpm install --frozen-lockfile'],
+    // installCommands:
+    //   process.platform === 'win32'
+    //     ? [
+    //         'pnpm config set node-linker hoisted --location project',
+    //         'pnpm install --frozen-lockfile',
+    //         'rm .npmrc',
+    //       ]
+    //     : ['pnpm install --frozen-lockfile'],
   },
   // {
   //   repoPath: 'upleveled/preflight-test-project-next-js-passing',
@@ -74,7 +75,7 @@ beforeAll(
           // `return pMap()` below
           return [
             await execaCommand('pnpm install --frozen-lockfile', {
-              cwd: `${fixturesTempDir}/${dirName}`,
+              cwd: `${tempDir}/${dirName}`,
             }),
           ];
         }
@@ -83,7 +84,7 @@ beforeAll(
           installCommands,
           (command) =>
             execaCommand(command, {
-              cwd: `${fixturesTempDir}/${dirName}`,
+              cwd: `${tempDir}/${dirName}`,
               // env: {
               //   PNPM_HOME: '/usr/local/bin',
               //   SHELL: 'bash',
@@ -131,15 +132,15 @@ test('Passes in the react-passing test project', async () => {
   }
 
   const { stdout, stderr } = await execaCommand(
-    '../../../../bin/preflight.js',
+    `${process.cwd()}/bin/preflight.js`,
     {
-      cwd: `${fixturesTempDir}/react-passing`,
+      cwd: `${tempDir}/react-passing`,
     },
   );
 
   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
-}, 70000);
+}, 30000);
 
 // test('Passes in the next-js-passing test project', async () => {
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -134,7 +134,7 @@ test('Passes in the react-passing test project', async () => {
 
   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
-}, 30000);
+}, 70000);
 
 // test('Passes in the next-js-passing test project', async () => {
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -65,9 +65,12 @@ beforeAll(
           // Return array to keep return type uniform with
           // `return pMap()` below
           return [
-            await execaCommand('pnpm install --frozen-lockfile', {
-              cwd: `${fixturesTempDir}/${dirName}`,
-            }),
+            await execaCommand(
+              'pnpm install --frozen-lockfile --shamefully-hoist',
+              {
+                cwd: `${fixturesTempDir}/${dirName}`,
+              },
+            ),
           ];
         }
 
@@ -105,24 +108,21 @@ function sortStdoutAndStripVersionNumber(stdout: string) {
 
 test('Passes in the react-passing test project', async () => {
   if (process.platform === 'win32') {
-    const { stdout: stdout1 } = await execaCommand('dir', {
-      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-plugin-jsx-expressions\\`,
-    });
-    console.log(stdout1);
-
-    const { stdout: stdout2 } = await execaCommand('dir', {
-      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\`,
-    });
-    console.log(stdout2);
-
-    const { stdout: stdout3 } = await execaCommand('type index.js', {
-      cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-config-upleveled\\`,
-    });
-    console.log(stdout3);
-
-    await execaCommand('pnpm install --shamefully-hoist', {
-      cwd: `${fixturesTempDir}/react-passing`,
-    });
+    // const { stdout: stdout1 } = await execaCommand('dir', {
+    //   cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-plugin-jsx-expressions\\`,
+    // });
+    // console.log(stdout1);
+    // const { stdout: stdout2 } = await execaCommand('dir', {
+    //   cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\`,
+    // });
+    // console.log(stdout2);
+    // const { stdout: stdout3 } = await execaCommand('type index.js', {
+    //   cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-config-upleveled\\`,
+    // });
+    // console.log(stdout3);
+    // await execaCommand('pnpm install --shamefully-hoist', {
+    //   cwd: `${fixturesTempDir}/react-passing`,
+    // });
   }
 
   const { stdout, stderr } = await execaCommand(

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -119,6 +119,10 @@ test('Passes in the react-passing test project', async () => {
       cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-config-upleveled\\`,
     });
     console.log(stdout3);
+
+    await execaCommand('pnpm install --shamefully-hoist', {
+      cwd: `${fixturesTempDir}/react-passing`,
+    });
   }
 
   const { stdout, stderr } = await execaCommand(


### PR DESCRIPTION
Avoid ESLint path resolution errors on Windows, such as [this test run failure](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750):

```
> @upleveled/preflight@4.0.0 test D:\a\preflight\preflight
> tsdx test "--ci" "--maxWorkers=2"

FAIL __tests__/e2e.test.ts (69.746 s)
  × Passes in the react-passing test project (9630 ms)
  × Passes in the next-js-passing test project (86[14](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:15) ms)

  ● Passes in the react-passing test project

    expect(received).toMatchSnapshot()

    Snapshot name: `Passes in the react-passing test project 1`

    - Snapshot  - 1
    + Received  + 0

    @@ -1,8 +1,7 @@
      "🚀 UpLeveled Preflight
      [COMPLETED] All changes committed to Git
    - [COMPLETED] ESLint
      [COMPLETED] ESLint config is latest version
      [COMPLETED] GitHub repo has deployed project link under About
      [COMPLETED] No dependencies without types
      [COMPLETED] No dependency problems
      [COMPLETED] No extraneous files committed to Git

      104 |   );
      105 |
    > 106 |   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
          |                                                   ^
      107 |   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
      108 | }, 30000);
      109 |

      at Object.<anonymous> (__tests__/e2e.test.ts:106:51)

  ● Passes in the react-passing test project
      [COMPLETED] ESLint config is latest version
      [COMPLETED] GitHub repo has deployed project link under About
      [COMPLETED] Next.js project has sharp installed
      [COMPLETED] No dependencies without types
      [COMPLETED] No dependency problems

      1[16](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:17) |   );
      1[17](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:18) |
    > 1[18](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:19) |   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
          |                                                   ^
      1[19](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:20) |   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
      1[20](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:21) | }, 45000);
      1[21](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:22) |

      at Object.<anonymous> (__tests__/e2e.test.ts:118:51)

  ● Passes in the next-js-passing test project

    expect(received).toMatchSnapshot()

    Snapshot name: `Passes in the next-js-passing test project 2`

    - Snapshot  -  1
    + Received  + 17

    - ""
    + "[FAILED] Command failed with exit code 2: pnpm eslint . --max-warnings 0 --format json
    +
    + Oops! Something went wrong! :(
    +
    + ESLint: 8.53.0
    +
    + Error: Cannot find package 'D:\a\preflight\preflight\__tests__\fixtures\__temp\next-js-passing\node_modules\.pnpm\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\node_modules\eslint-plugin-jsx-expressions\package.json' imported from D:\a\preflight\preflight\__tests__\fixtures\__temp\next-js-passing\node_modules\.pnpm\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\node_modules\eslint-config-upleveled\index.js
    + Did you mean to import eslint-plugin-jsx-expressions@1.3.1_@typescript-eslint+parser@6.10.0_eslint@8.53.0_typescript@5.2.2/node_modules/eslint-plugin-jsx-expressions/dist/index.js?
    +     at legacyMainResolve (node:internal/modules/esm/resolve:189:26)
    +     at packageResolve (node:internal/modules/esm/resolve:776:14)
    +     at moduleResolve (node:internal/modules/esm/resolve:838:20)
    +     at defaultResolve (node:internal/modules/esm/resolve:1043:11)
    +     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
    +     at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
    +     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:[22](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:23)8:38)
    +     at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    +     at link (node:internal/modules/esm/module_job:84:[36](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:37))"

      117 |
      118 |   expect(sortStdoutAndStripVersionNumber(stdout)).toMatchSnapshot();
    > 119 |   expect(stderr.replace(/^\(node:\d+\) /, '')).toMatchSnapshot();
          |                                                ^
      120 | }, 45000);
      121 |

      at Object.<anonymous> (__tests__/e2e.test.ts:119:48)

 › 4 snapshots failed.
Snapshot Summary
 › 4 snapshots failed from 1 test suite. Inspect your code changes or re-run jest with `-u` to update them.

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
Snapshots:   4 failed, 4 total
Time:        70.[43](https://github.com/upleveled/preflight/actions/runs/6842461034/job/18603950750#step:15:44)6 s
Ran all test suites.
 ELIFECYCLE  Test failed. See above for more details.
Error: Process completed with exit code 1.
```

Funny enough, the file that it cannot resolve above (`D:\a\preflight\preflight\__tests__\fixtures\__temp\next-js-passing\node_modules\.pnpm\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\node_modules\eslint-plugin-jsx-expressions\package.json`) actually does exist on disk:

```js
const { stdout: stdout1 } = await execaCommand('dir', {
  cwd: `D:\\a\\preflight\\preflight\\__tests__\\fixtures\\__temp\\react-passing\\node_modules\\.pnpm\\eslint-config-upleveled@7.0.0_@babel+eslint-parser@7.23.3_@next+eslint-plugin-next@14.0.2_@ty_xvhbeu5qc6hlxssq5gmtnagbti\\node_modules\\eslint-plugin-jsx-expressions\\`,
});
console.log(stdout1);
// README.md  dist  docs  node_modules  package.json
```

So seems like a bug in ESLint's package resolution, [opened an issue](https://github.com/upleveled/preflight/pull/469#issuecomment-1812422819)