### PR TITLE
BREAKING: Exit with non-zero exit code on errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,9 @@ const listrTasks = [
   };
 });
 
-await new Listr(listrTasks, {
+const tasks = new Listr(listrTasks, {
   exitOnError: false,
+  collectErrors: 'minimal',
   rendererOptions: {
     collapseErrors: false,
     removeEmptyLines: false,
@@ -104,4 +105,10 @@ await new Listr(listrTasks, {
   },
   fallbackRenderer: 'verbose',
   concurrent: 5,
-}).run();
+});
+
+await tasks.run();
+
+if (tasks.errors.length > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
Use [the `listr2` `collectErrors` option and `tasks.errors`](https://github.com/listr2/listr2/issues/645#issuecomment-1816158970) to exit with non-zero code (exit code 1)

Enables simpler usage in GitHub Actions / terminal:

- https://github.com/upleveled/next-portfolio-dev/pull/97/commits/be171a47cf8d37069ee016ca1f2d87037f71c225