### PR TITLE
Use array syntax for execa git clone command 

### DIFF
--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -21,7 +21,7 @@ await execa({
   // Reset default for the `git clone` command before projectPath exists
   cwd: cwd(),
 })`git clone --depth 1 ${
-  !argv[3] ? [] : `--branch ${argv[3]}`
+  !argv[3] ? [] : ['--branch', argv[3]]
 } --single-branch ${argv[2]} ${projectPath} --config core.autocrlf=input`;
 
 console.log('Installing dependencies...');


### PR DESCRIPTION
When running Preflight with GitHub Actions on a specific branch, the test throws an [error](https://github.com/upleveled/next-portfolio-dev/actions/runs/9363999176/job/25776014877?pr=107):
```
ExecaError: Command failed with exit code 129: git clone --depth 1 '--branch renovate/octokit-monorepo' --single-branch 'https://github.com/upleveled/next-portfolio-dev' project-to-check --config 'core.autocrlf=input'
```

To fix this error,  the `git clone` command was changed to use an `array` syntax for the branch argument instead of a string template literal. As documented in the [execa docs](https://github.com/sindresorhus/execa/blob/main/docs/execution.md#no-arguments)