### PR TITLE
Ignore paths in `.gitignore` for Stylelint

### DIFF
--- a/src/checks/stylelint.ts
+++ b/src/checks/stylelint.ts
@@ -22,7 +22,7 @@ export default async function stylelintCheck() {
       preferLocal: true,
     })`stylelint **/*.{${supportedStylelintFileExtensions.join(
       ',',
-    )}} --max-warnings 0 --formatter json`;
+    )}} --ignore-path .gitignore --max-warnings 0 --formatter json`;
   } catch (error) {
     const { stderr } = error as { stderr: string };
 


### PR DESCRIPTION
If Playwright has generated a report, this causes Stylelint failures (see below). Instead we should [ignore files using `.gitignore` for Stylelint](https://github.com/stylelint/stylelint/issues/2511#issuecomment-294886098).

```bash
$ preflight
🚀 UpLeveled Preflight v8.0.1
√ All changes committed to Git
√ node_modules/ folder ignored in Git
√ No extraneous files committed to Git
√ No secrets committed to Git
√ Use single package manager
√ Project folder name matches correct format
√ No dependency problems
√ GitHub repo has deployed project link under About
√ ESLint
× Stylelint
  › Stylelint problems found in the following files:
  playwright\report\trace\codeMirrorModule.ez37Vkbh.css
  playwright\report\trace\inspectorTab.DLjBDrQR.css
  playwright\report\trace\uiMode.CAYqod-m.css
  playwright\report\trace\workbench.D3JVcA9K.css

  Open these files in your editor - there should be problems to fix
√ Prettier
√ ESLint config is latest version
√ Stylelint config is latest version
√ Preflight is latest version
```