### PR TITLE
Switch bin to Bash script to avoid "tsx not found"

### DIFF
--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -12,7 +12,7 @@ exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 
 cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"([^"]+)".*/\1/')
 cli_path="${cli_path/\$basedir/$script_dir}"
 pnpm_bin_global="$(pnpm bin --global)"
-cli_path="${cli_path/\/$pnpm_bin_global\//\/$pnpm_bin_global\/global\/5\/.pnpm\/}"
+cli_path="${cli_path/$pnpm_bin_global\//$pnpm_bin_global\/global\/5\/.pnpm\/}"
 
 if [[ ! -x "$cli_path" ]]; then
   echo "Error: tsx executable not found or is not executable at $cli_path" >&2

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+cd "$SCRIPT_DIR" || exit 1
+
+pnpm exec tsx "./src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 # Workaround for incorrect path in pnpm shim
 # https://github.com/pnpm/pnpm/issues/8704#issuecomment-2439618363
 #
-# TODO: Remove and switch back to "$script_dir/../node_modules/bin"
+# TODO: Remove and switch back to "$script_dir/../node_modules/.bin/tsx"
 # when the issue above is resolved
 tsx_shim="$script_dir/../node_modules/.bin/tsx"
 exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 'exec node')
@@ -13,4 +13,5 @@ cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"(
 cli_path="${cli_path/\$basedir/$script_dir}"
 cli_path="${cli_path/\/pnpm\//\/pnpm\/global\/5\/.pnpm\/}"
 
-node "$cli_path" "$script_dir/../src/index.ts"
+# node "$cli_path" "$script_dir/../src/index.ts"
+node "$script_dir/../node_modules/.bin/tsx" "$script_dir/../src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -11,7 +11,8 @@ tsx_shim="$script_dir/../node_modules/.bin/tsx"
 exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 'exec node')
 cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"([^"]+)".*/\1/')
 cli_path="${cli_path/\$basedir/$script_dir}"
-cli_path="${cli_path/\/pnpm\//\/pnpm\/global\/5\/.pnpm\/}"
+pnpm_bin_global="$(pnpm bin --global)"
+cli_path="${cli_path/\/$pnpm_bin_global\//\/$pnpm_bin_global\/global\/5\/.pnpm\/}"
 
 if [[ ! -x "$cli_path" ]]; then
   echo "Error: tsx executable not found or is not executable at $cli_path" >&2

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -14,18 +14,4 @@ cli_path="${cli_path/\$basedir/$script_dir}"
 pnpm_bin_global="$(pnpm bin --global)"
 cli_path="${cli_path/$pnpm_bin_global\//$pnpm_bin_global\/global\/5\/.pnpm\/}"
 
-# if [[ ! -x "$cli_path" ]]; then
-#   echo "Error: tsx executable not found or is not executable at $cli_path" >&2
-#   # pnpm bin --global
-#   echo "pnpm bin --global: $(pnpm bin --global)"
-#   echo "script_dir: $script_dir"
-#   cd "$script_dir/.." || exit 1
-#   echo "$script_dir/node_modules/.bin files:"
-#   ls -la node_modules/.bin
-#   echo "tsx shim contents:"
-#   cat "$tsx_shim"
-#   echo "exec_command: $exec_command"
-#   exit 1
-# fi
-
 node "$cli_path" "$script_dir/../src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -13,5 +13,16 @@ cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"(
 cli_path="${cli_path/\$basedir/$script_dir}"
 cli_path="${cli_path/\/pnpm\//\/pnpm\/global\/5\/.pnpm\/}"
 
-# node "$cli_path" "$script_dir/../src/index.ts"
-node "$script_dir/../node_modules/.bin/tsx" "$script_dir/../src/index.ts"
+if [[ ! -x "$cli_path" ]]; then
+  echo "Error: tsx executable not found or is not executable at $cli_path" >&2
+  echo "script_dir: $script_dir"
+  cd "$script_dir/.." || exit 1
+  echo "$script_dir/node_modules/.bin files:"
+  ls -la node_modules/.bin
+  echo "tsx shim contents:"
+  cat "$tsx_shim"
+  echo "exec_command: $exec_command"
+  exit 1
+fi
+
+node "$cli_path" "$script_dir/../src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -10,11 +10,11 @@ echo "script_dir: $script_dir"
 # when the issue above is resolved
 tsx_shim="$script_dir/../node_modules/.bin/tsx"
 exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 'exec node')
-cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"([^"]+)".*/\1/')
-cli_path="${cli_path/\$basedir/$script_dir}"
-pnpm_bin_global="$(pnpm bin --global)"
-echo "pnpm_bin_global: $pnpm_bin_global"
-cli_path="${cli_path/$pnpm_bin_global\//$pnpm_bin_global\/global\/5\/.pnpm\/}"
-echo "cli_path: $cli_path"
+cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"[^"]+(node_modules/tsx/[^"]+)".*/\1/')
+cli_path="$(pnpm bin --global)/global/5/.pnpm/$cli_path"
+# # pnpm_bin_global="$(pnpm bin --global)/global/5/.pnpm/$cli_path"
+# # echo "pnpm_bin_global: $pnpm_bin_global"
+# cli_path="${cli_path/$pnpm_bin_global\//$pnpm_bin_global\/global\/5\/.pnpm\/}"
+# echo "cli_path: $cli_path"
 
 node "$cli_path" "$script_dir/../src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+echo "script_dir: $script_dir"
 
 # Workaround for incorrect path in pnpm shim
 # https://github.com/pnpm/pnpm/issues/8704#issuecomment-2439618363
@@ -12,6 +13,8 @@ exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 
 cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"([^"]+)".*/\1/')
 cli_path="${cli_path/\$basedir/$script_dir}"
 pnpm_bin_global="$(pnpm bin --global)"
+echo "pnpm_bin_global: $pnpm_bin_global"
 cli_path="${cli_path/$pnpm_bin_global\//$pnpm_bin_global\/global\/5\/.pnpm\/}"
+echo "cli_path: $cli_path"
 
 node "$cli_path" "$script_dir/../src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -10,7 +10,7 @@ echo "script_dir: $script_dir"
 # when the issue above is resolved
 tsx_shim="$script_dir/../node_modules/.bin/tsx"
 exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 'exec node')
-cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"[^"]+(node_modules/tsx/[^"]+)".*/\1/')
+cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"[^"]+(node_modules\/tsx\/[^"]+)".*/\1/')
 cli_path="$(pnpm bin --global)/global/5/.pnpm/$cli_path"
 # # pnpm_bin_global="$(pnpm bin --global)/global/5/.pnpm/$cli_path"
 # # echo "pnpm_bin_global: $pnpm_bin_global"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -14,18 +14,18 @@ cli_path="${cli_path/\$basedir/$script_dir}"
 pnpm_bin_global="$(pnpm bin --global)"
 cli_path="${cli_path/$pnpm_bin_global\//$pnpm_bin_global\/global\/5\/.pnpm\/}"
 
-if [[ ! -x "$cli_path" ]]; then
-  echo "Error: tsx executable not found or is not executable at $cli_path" >&2
-  # pnpm bin --global
-  echo "pnpm bin --global: $(pnpm bin --global)"
-  echo "script_dir: $script_dir"
-  cd "$script_dir/.." || exit 1
-  echo "$script_dir/node_modules/.bin files:"
-  ls -la node_modules/.bin
-  echo "tsx shim contents:"
-  cat "$tsx_shim"
-  echo "exec_command: $exec_command"
-  exit 1
-fi
+# if [[ ! -x "$cli_path" ]]; then
+#   echo "Error: tsx executable not found or is not executable at $cli_path" >&2
+#   # pnpm bin --global
+#   echo "pnpm bin --global: $(pnpm bin --global)"
+#   echo "script_dir: $script_dir"
+#   cd "$script_dir/.." || exit 1
+#   echo "$script_dir/node_modules/.bin files:"
+#   ls -la node_modules/.bin
+#   echo "tsx shim contents:"
+#   cat "$tsx_shim"
+#   echo "exec_command: $exec_command"
+#   exit 1
+# fi
 
 node "$cli_path" "$script_dir/../src/index.ts"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -15,6 +15,8 @@ cli_path="${cli_path/\/pnpm\//\/pnpm\/global\/5\/.pnpm\/}"
 
 if [[ ! -x "$cli_path" ]]; then
   echo "Error: tsx executable not found or is not executable at $cli_path" >&2
+  # pnpm bin --global
+  echo "pnpm bin --global: $(pnpm bin --global)"
   echo "script_dir: $script_dir"
   cd "$script_dir/.." || exit 1
   echo "$script_dir/node_modules/.bin files:"

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
-cd "$SCRIPT_DIR" || exit 1
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-pnpm exec tsx "./src/index.ts"
+# Workaround for incorrect path in pnpm shim
+# https://github.com/pnpm/pnpm/issues/8704#issuecomment-2439618363
+#
+# TODO: Remove and switch back to "$script_dir/../node_modules/bin"
+# when the issue above is resolved
+tsx_shim="$script_dir/../node_modules/.bin/tsx"
+exec_command=$(awk '/^else$/{flag=1;next}/^fi$/{flag=0}flag' "$tsx_shim" | grep 'exec node')
+cli_path=$(echo "$exec_command" | sed -E 's/^[[:space:]]*exec node[[:space:]]+"([^"]+)".*/\1/')
+cli_path="${cli_path/\$basedir/$script_dir}"
+cli_path="${cli_path/\/pnpm\//\/pnpm\/global\/5\/.pnpm\/}"
+
+node "$cli_path" "$script_dir/../src/index.ts"

--- a/bin/preflight.ts
+++ b/bin/preflight.ts
@@ -1,3 +1,0 @@
-#!/usr/bin/env -S pnpm exec tsx
-
-import '../src/index.ts';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "module": "./src/index.ts",
   "types": "./src/index.ts",
   "bin": {
-    "preflight": "./bin/preflight.ts"
+    "preflight": "./bin/preflight.sh"
   },
   "files": [
     "./bin/preflight.js",


### PR DESCRIPTION
First encountered over here:

- https://github.com/upleveled/preflight-test-project-react-passing/pull/940#issuecomment-2437582889

Also, the paths in the pnpm bin shims for dependencies of globally-installed packages is currently broken, so added a workaround for that:

- https://github.com/pnpm/pnpm/issues/8704