### PR TITLE
Fix NaN issue in Execa by extracting `.stdout`

### DIFF
--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --experimental-strip-types
 
 import { argv, cwd, exit } from 'node:process';
-import { execa as bindExeca } from 'execa';
+import { $, execa as bindExeca } from 'execa';
 
 if (
   !argv[2] ||
@@ -64,7 +64,7 @@ if (projectUsesPostgresql) {
   //
   // Example script:
   // https://github.com/upleveled/preflight-test-project-next-js-passing/blob/e65717f6951b5336bb0bd83c15bbc99caa67ebe9/scripts/alpine-postgresql-setup-and-start.sh
-  const postgresUid = Number(await execa`id -u postgres`);
+  const postgresUid = Number((await $`id -u postgres`).stdout);
   await execa({
     // postgres user, for initdb and pg_ctl
     uid: postgresUid,

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --experimental-strip-types
 
 import { argv, cwd, exit } from 'node:process';
-import { $, execa as bindExeca } from 'execa';
+import { execa as bindExeca } from 'execa';
 
 if (
   !argv[2] ||
@@ -64,7 +64,7 @@ if (projectUsesPostgresql) {
   //
   // Example script:
   // https://github.com/upleveled/preflight-test-project-next-js-passing/blob/e65717f6951b5336bb0bd83c15bbc99caa67ebe9/scripts/alpine-postgresql-setup-and-start.sh
-  const postgresUid = Number((await $`id -u postgres`).stdout);
+  const postgresUid = Number((await execa`id -u postgres`).stdout);
   await execa({
     // postgres user, for initdb and pg_ctl
     uid: postgresUid,


### PR DESCRIPTION
Closes #588

The Preflight Docker container failed when trying to set the `uid` for the PostgreSQL setup script. The issue was that Execa returns an `object`, and `Number()` was called on the object instead of just the command output, resulting in `NaN`. This caused Execa to throw this error:

```bash
'The "options.uid" property must be int32. Received type number (NaN)'
```

It wasn’t clear why the value was `NaN`. We assumed that `execa` returned a `string`, but it returns an `object` containing the command output under `.stdout`. It failed because `Number()` was called on the entire object instead of extracting `.stdout` first. 

```bash
const postgresUid = Number(await execa`id -u postgres`); // Fails: Execa result object → NaN
```

To fix this error, we need to extract `.stdout` before converting to a number.

```bash
const postgresUid = Number((await $`id -u postgres`).stdout); // Works: Extracts string output
```

ESLint didn’t catch this issue because `Number({})` is currently not flagged as an error. A proposal has been made to TypeScript ESLint to introduce a rule preventing passing `objects` to `Number()`.
- https://github.com/typescript-eslint/typescript-eslint/issues/10895 





