### PR TITLE
Add support for student project environment variables

### DIFF
--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -56,7 +56,10 @@ if (projectUsesPostgresql) {
       const match = line.match(/^([A-Z0-9_]+)=/);
       if (match) {
         const key = match[1];
-        process.env[key] = key === 'PGHOST' ? 'localhost' : 'project_to_check';
+        if (key) {
+          process.env[key] =
+            key === 'PGHOST' ? 'localhost' : 'project_to_check';
+        }
       }
     });
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -64,10 +64,9 @@ if (projectUsesPostgresql) {
   //
   // Example script:
   // https://github.com/upleveled/preflight-test-project-next-js-passing/blob/e65717f6951b5336bb0bd83c15bbc99caa67ebe9/scripts/alpine-postgresql-setup-and-start.sh
-  const postgresUid = Number((await execa`id -u postgres`).stdout);
   const postgresProcess = await execa({
     // postgres user, for initdb and pg_ctl
-    uid: postgresUid,
+    uid: Number((await execa`id -u postgres`).stdout),
     // Show output to simplify debugging
     stdout: ['inherit', 'pipe'],
     stderr: ['inherit', 'pipe'],

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -46,8 +46,8 @@ if (projectUsesPostgresql) {
   await execa`mkdir -p /postgres-volume/run/postgresql/data`;
   await execa`chown -R postgres:postgres /postgres-volume/run/postgresql`;
 
-  // Set database connection environment variables from .env.example,
-  // inherited in all future execa calls
+  // Set database connection environment variables, inherited in
+  // all future execa calls
   process.env.PGHOST = 'localhost';
   process.env.PGDATABASE = 'project_to_check';
   process.env.PGUSERNAME = 'project_to_check';

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --experimental-strip-types
 
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { argv, cwd, exit } from 'node:process';
 import { execa as bindExeca } from 'execa';

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -73,17 +73,15 @@ if (projectUsesPostgresql) {
     stderr: 'inherit',
   })`bash ./scripts/alpine-postgresql-setup-and-start.sh`;
 
+  console.log(postgresProcess.stdout);
+
   const preflightEnvironmentVariables = postgresProcess.stdout.match(
     /PREFLIGHT_ENVIRONMENT_VARIABLES:\n(\[[^\]]+\])/,
   )?.[1];
 
   if (preflightEnvironmentVariables) {
-    const environmentVariablesKeys: string[] = JSON.parse(
-      preflightEnvironmentVariables,
-    );
-
-    for (const key of environmentVariablesKeys) {
-      process.env[key] = `fake_${key.toLowerCase()}`;
+    for (const key of JSON.parse(preflightEnvironmentVariables) as string[]) {
+      process.env[key] = `MISSING_ENV_${key}`;
     }
   }
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -73,22 +73,17 @@ if (projectUsesPostgresql) {
     stderr: 'inherit',
   })`bash ./scripts/alpine-postgresql-setup-and-start.sh`;
 
-  const output = postgresProcess.stdout;
-  const startMarker = 'ENVIRONMENT VARIABLES START';
-  const endMarker = 'ENVIRONMENT VARIABLES END';
+  const preflightEnvironmentVariables = postgresProcess.stdout.match(
+    /PREFLIGHT_ENVIRONMENT_VARIABLES:\n(\[.*?\])/,
+  )?.[1];
 
-  const startIndex = output.indexOf(startMarker);
-  const endIndex = output.indexOf(endMarker);
+  if (preflightEnvironmentVariables) {
+    const environmentVariablesKeys: string[] = JSON.parse(
+      preflightEnvironmentVariables,
+    );
 
-  const envLines = output
-    .slice(startIndex + startMarker.length, endIndex)
-    .trim()
-    .split('\n');
-
-  for (const line of envLines) {
-    const [key, value] = line.split('=');
-    if (key && value) {
-      process.env[key.trim()] = value.trim();
+    for (const key of environmentVariablesKeys) {
+      process.env[key] = `fake_${key.toLowerCase()}`;
     }
   }
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -50,19 +50,26 @@ if (projectUsesPostgresql) {
 
   // Set database connection environment variables from .env.example,
   // inherited in all future execa calls
-  readFileSync(join(projectPath, '.env.example'), 'utf-8')
-    .split('\n')
-    .forEach((line) => {
-      const match = line.match(/^([A-Z0-9_]+)=/);
-      if (match) {
-        const key = match[1];
-        if (key) {
-          process.env[key] =
-            key === 'PGHOST' ? 'localhost' : 'project_to_check';
-        }
-      }
-    });
+  const envLines = readFileSync(
+    join(projectPath, '.env.example'),
+    'utf-8',
+  ).split('\n');
 
+  for (const line of envLines) {
+    // Skip comments and empty lines
+    if (!line || line.startsWith('#') || !line.includes('=')) continue;
+
+    // Split after the first '=' character
+    const [key] = line.split('=', 2);
+    if (!key) continue;
+
+    process.env[key] =
+      key === 'PGHOST'
+        ? 'localhost'
+        : key.startsWith('PG')
+          ? 'project_to_check'
+          : 'example_value';
+  }
   // Run script as postgres user to:
   // - Create data directory
   // - Init database

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -74,7 +74,7 @@ if (projectUsesPostgresql) {
   })`bash ./scripts/alpine-postgresql-setup-and-start.sh`;
 
   const preflightEnvironmentVariables = postgresProcess.stdout.match(
-    /PREFLIGHT_ENVIRONMENT_VARIABLES:\n(\[.*?\])/,
+    /PREFLIGHT_ENVIRONMENT_VARIABLES:\n(\[[^\]]+\])/,
   )?.[1];
 
   if (preflightEnvironmentVariables) {

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -69,11 +69,9 @@ if (projectUsesPostgresql) {
     // postgres user, for initdb and pg_ctl
     uid: postgresUid,
     // Show output to simplify debugging
-    stdout: 'pipe',
-    stderr: 'inherit',
+    stdout: ['inherit', 'pipe'],
+    stderr: ['inherit', 'pipe'],
   })`bash ./scripts/alpine-postgresql-setup-and-start.sh`;
-
-  console.log(postgresProcess.stdout);
 
   const preflightEnvironmentVariables = postgresProcess.stdout.match(
     /PREFLIGHT_ENVIRONMENT_VARIABLES:\n(\[[^\]]+\])/,

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -79,7 +79,7 @@ if (projectUsesPostgresql) {
 
   if (preflightEnvironmentVariables) {
     for (const key of JSON.parse(preflightEnvironmentVariables) as string[]) {
-      process.env[key] = `MISSING_ENV_${key}`;
+      process.env[key] = `UPLEVELED_PREFLIGHT_PLACEHOLDER`;
     }
   }
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -79,7 +79,7 @@ if (projectUsesPostgresql) {
 
   if (preflightEnvironmentVariables) {
     for (const key of JSON.parse(preflightEnvironmentVariables) as string[]) {
-      process.env[key] = `UPLEVELED_PREFLIGHT_PLACEHOLDER`;
+      process.env[key] = 'UPLEVELED_PREFLIGHT_PLACEHOLDER';
     }
   }
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -74,8 +74,8 @@ if (projectUsesPostgresql) {
   })`bash ./scripts/alpine-postgresql-setup-and-start.sh`;
 
   const output = postgresProcess.stdout;
-  const startMarker = '### START_ENV ###';
-  const endMarker = '### END_ENV ###';
+  const startMarker = 'ENVIRONMENT VARIABLES START';
+  const endMarker = 'ENVIRONMENT VARIABLES END';
 
   const startIndex = output.indexOf(startMarker);
   const endIndex = output.indexOf(endMarker);

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S node --experimental-strip-types
 
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { argv, cwd, exit } from 'node:process';
 import { execa as bindExeca } from 'execa';
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -77,8 +77,8 @@ if (projectUsesPostgresql) {
   )?.[1];
 
   if (preflightEnvironmentVariables) {
-    for (const key of JSON.parse(preflightEnvironmentVariables) as string[]) {
-      process.env[key] = 'UPLEVELED_PREFLIGHT_PLACEHOLDER';
+    for (const name of JSON.parse(preflightEnvironmentVariables) as string[]) {
+      process.env[name] = 'UPLEVELED_PREFLIGHT_PLACEHOLDER';
     }
   }
 

--- a/docker/clone-and-preflight.ts
+++ b/docker/clone-and-preflight.ts
@@ -55,20 +55,13 @@ if (projectUsesPostgresql) {
   process.env.PGUSERNAME = 'project_to_check';
   process.env.PGPASSWORD = 'project_to_check';
 
-  const envLines = readFileSync(
-    join(projectPath, '.env.example'),
-    'utf-8',
-  ).split('\n');
+  const envLines = readFileSync(join(projectPath, '.env.example'), 'utf-8')
+    .split('\n')
+    .filter((line) => line && line.includes('='));
 
   for (const line of envLines) {
-    if (!line || line.startsWith('#') || !line.includes('=')) continue;
-
     const [key] = line.split('=', 2);
-    if (!key) continue;
-
-    if (key in process.env) {
-      continue;
-    }
+    if (!key || key in process.env) continue;
 
     process.env[key] = 'example_value';
   }


### PR DESCRIPTION
- https://github.com/sindresorhus/execa/issues/1191

Prerequisite for 
- https://github.com/upleveled/next-js-example-winter-2025-eu/pull/3

Preflight is failing in [Alex Ecommerce Store Project](https://github.com/alexneumayr/next-js-ecommerce-store) due to missing `env` variables. This project is the first to include additional environment variables beyond the database ones we teach in the lectures. Since we don't check the `.env.example` file, Preflight was relying on only the default environment variables, causing it to fail during the dotenv-safe check.

```bash
MissingEnvVarsError: The following variables were defined in .env.example but are not present in the environment:
  NEXTAUTH_URL, NEXTAUTH_SECRET, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET
Make sure to add them to .env or directly to the environment.

ENOENT: no such file or directory, open '/preflight/project-to-check/.env'
    at config (/preflight/project-to-check/node_modules/.pnpm/dotenv-safe@9.1.0_dotenv@8.6.0/node_modules/dotenv-safe/index.js:31:19)
    at setEnvironmentVariables (file:///preflight/project-to-check/util/config.js:24:3)
    at file:///preflight/project-to-check/ley.config.js:3:1
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async exports.load (/preflight/project-to-check/node_modules/.pnpm/@upleveled+ley@0.9.2/node_modules/@upleveled/ley/lib/util.js:59:11)
    at async /preflight/project-to-check/node_modules/.pnpm/@upleveled+ley@0.9.2/node_modules/@upleveled/ley/bin.js:11:13 {
  missing: [
    'NEXTAUTH_URL',
    'NEXTAUTH_SECRET',
    'CLOUDINARY_CLOUD_NAME',
    'CLOUDINARY_API_KEY',
    'CLOUDINARY_API_SECRET'
  ],
  sample: '.env.example',
  example: '.env.example'
}

Node.js v22.14.0
```

This PR updates how Preflight handles additional environment variables. The `alpine-postgresql-setup-and-start.sh` script now prints the required variables. Preflight captures this output using `stdout: pipe`, extracts the exact line, and creates environment variables with fake values. With this PR Preflight runs without failing due to missing environment variables.

Preflight output after a successful test

```bash
Cloning https://github.com/ProchaLu/drone-preflight-env...
Installing dependencies...
Setting up PostgreSQL database...
initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
Running migrations...
Running Preflight...
🚀 UpLeveled Preflight v8.0.6
[STARTED] All changes committed to Git
[STARTED] node_modules/ folder ignored in Git
[STARTED] No extraneous files committed to Git
[STARTED] No secrets committed to Git
[STARTED] Use single package manager
[COMPLETED] No secrets committed to Git
[STARTED] Project folder name matches correct format
[COMPLETED] Project folder name matches correct format
[STARTED] No dependency problems
[STARTED] No unused dependencies
[STARTED] No dependencies without types
[COMPLETED] No extraneous files committed to Git
[STARTED] GitHub repo has deployed project link under About
[COMPLETED] Use single package manager
[STARTED] ESLint
[COMPLETED] node_modules/ folder ignored in Git
[STARTED] Stylelint
[COMPLETED] All changes committed to Git
[STARTED] Prettier
[COMPLETED] GitHub repo has deployed project link under About
[STARTED] ESLint config is latest version
[COMPLETED] No dependencies without types
[COMPLETED] ESLint config is latest version
[STARTED] Stylelint config is latest version
[COMPLETED] No unused dependencies
[COMPLETED] No dependency problems
[STARTED] Preflight is latest version
[COMPLETED] Stylelint
[COMPLETED] Stylelint config is latest version
[COMPLETED] Prettier
[COMPLETED] Preflight is latest version
[COMPLETED] ESLint
```
