### PR TITLE
Ignore Expo dependencies erroneously reported as unused

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -59,6 +59,14 @@ export default async function noUnusedAndMissingDependencies() {
 
     // Next.js
     'sharp',
+
+    // Expo
+    '@babel/core',
+    'expo-build-properties',
+    'expo-splash-screen',
+    'expo-system-ui',
+    'react-dom',
+    'react-native-gesture-handler',
   ].join(',');
 
   try {


### PR DESCRIPTION
Closes #628

Add new dependencies which are implicitly required by Expo, and incorrectly reported as Depcheck as unused.