### PR TITLE
Ignore .expo in Preflight to avoid ESLint disable errors

### DIFF
--- a/src/checks/eslintConfigIsValid.ts
+++ b/src/checks/eslintConfigIsValid.ts
@@ -69,7 +69,8 @@ export default async function eslintConfigIsValid() {
 
   for await (const { path } of readdirp('.', {
     directoryFilter: (dir) =>
-      !['.git', '.next', 'node_modules'].includes(dir.basename),
+      // TODO: Read `.gitignore` to add ignored folders and files to this hardcoded array
+      !['.expo', '.git', '.next', 'node_modules'].includes(dir.basename),
     fileFilter: (file) => /\.(?:js|jsx|ts|tsx)$/.test(file.basename),
   })) {
     const fileContents = await fs.readFile(path, 'utf-8');


### PR DESCRIPTION
Running Preflight in an Expo React Native application triggered the following error:

```bash
✖ ESLint config is latest version
  › ESLint has been disabled in the following files:
    .expo/types/router.d.ts

    Remove all comments disabling or modifying ESLint rule configuration (eg. eslint-disable and eslint-disable-next-line comments) and fix the problems
```

Expo adds a `/* eslint-disable */` comment to one of its generated files inside the `.expo` folder. While this folder is correctly ignored by ESLint, Preflight still checks it and fails. This PR updates the hardcoded ignore list to include `.expo`.

Longer term, we want to read `.gitignore` to generate this list dynamically.








