### PR TITLE
Switch to hardcoded Node.js version + Renovate to avoid action lag

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - run: pnpm install

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -64,15 +64,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # Upgrade to at least corepack@0.31.0 to avoid
-      # `Cannot find matching keyid` error
-      # https://github.com/karlhorky/upleveled.io/pull/850#issuecomment-2646349719
-      #
-      # Uses `--force` to overwrite Yarn v1 binary
-      #
-      # TODO: Remove when GitHub Actions runners have corepack@>=0.31.0
-      - run: npm install --global --force corepack@>=0.31.0
-
       - run: corepack enable
 
       # Set up PNPM_HOME directory to avoid errors such
@@ -98,7 +89,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
`actions/setup-node` has multiple days / weeks of lag behind new Node.js versions:

- https://github.com/actions/setup-node/issues/940
- https://github.com/actions/setup-node/issues/1236

Switch back to `actions/setup-node`, but with a hardcoded version number which is upgraded instead through Renovate bot PRs.

- [x] Switch to hardcoded Node.js version