### PR TITLE
Fix $PNPM_HOME path in Dockerfile for pnpm v11+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN pnpm install --frozen-lockfile
 
 # Enable `pnpm add --global` on Alpine Linux by setting
-# home location environment variable to a location already in $PATH
+# a dedicated pnpm home directory and adding its bin directory to $PATH
 # https://github.com/pnpm/pnpm/issues/784#issuecomment-1518582235
-ENV PNPM_HOME=/usr/local
+ENV PNPM_HOME=/pnpm
+ENV PATH="$PNPM_HOME/bin:$PATH"
 
 RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ ENV CI=true
 RUN apk update
 RUN apk add --no-cache coreutils git postgresql python3 py3-pip build-base bash
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN pnpm install --frozen-lockfile
-
 # Enable `pnpm add --global` on Alpine Linux by setting
 # a dedicated pnpm home directory and adding its bin directory to $PATH
 # https://github.com/pnpm/pnpm/issues/784#issuecomment-1518582235
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME/bin:$PATH"
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN pnpm install --frozen-lockfile
 
 RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pnpm install --frozen-lockfile
 # Enable `pnpm add --global` on Alpine Linux by setting
 # home location environment variable to a location already in $PATH
 # https://github.com/pnpm/pnpm/issues/784#issuecomment-1518582235
-ENV PNPM_HOME=/usr/local/bin
+ENV PNPM_HOME=/usr/local
 
 RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
 


### PR DESCRIPTION
[pnpm v11 changed the global bin directory](https://pnpm.io/blog/releases/11.0#isolated-global-virtual-store-global-installs) from `PNPM_HOME` to `$PNPM_HOME/bin`, so our existing `PNPM_HOME=/usr/local/bin` Alpine Linux configuration resolves to `/usr/local/bin/bin`, which is not in `PATH` ([failing GitHub Actions workflow run for building the Docker image](https://github.com/upleveled/preflight/actions/runs/33903495733/job/101122857493)):

```bash
#13 [ 8/10] RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
#13 0.727 [ERROR] The configured global bin directory "/usr/local/bin/bin" is not in PATH
#13 0.727 Run "pnpm setup" to update your shell configuration.
#13 ERROR: process "/bin/sh -c pnpm add --global --allow-build=esbuild @upleveled/preflight@latest" did not complete successfully: exit code: 1
------
 > [ 8/10] RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest:
0.727 [ERROR] The configured global bin directory "/usr/local/bin/bin" is not in PATH
0.727 Run "pnpm setup" to update your shell configuration.
------
Dockerfile:26
--------------------
  24 |     ENV PNPM_HOME=/usr/local/bin
  25 |     
  26 | >>> RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
  27 |     
  28 |     COPY ./docker/clone-and-preflight.ts ./
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pnpm add --global --allow-build=esbuild @upleveled/preflight@latest" did not complete successfully: exit code: 1
```

Update the `Dockerfile` to set `PNPM_HOME=/pnpm` and add `/pnpm/bin` to `PATH`, matching [pnpm's current Docker image configuration](https://github.com/pnpm/pnpm/blob/9440b519f3b8d81d43f11ba470acb7bd12ce3780/docker/Dockerfile#L12-L13) (also mentioned in [the pnpm Docker docs](https://pnpm.io/docker#minimizing-docker-image-size-and-build-time)). Also set these environment variables before the first installation of pnpm by Corepack and usage with `pnpm install`.