### PR TITLE
Fix old Preflight in image via pnpm global config, pin upgrade version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN pnpm install --frozen-lockfile
 
+# Apply pnpm's minimumReleaseAge settings to the global install below:
+# pnpm reads global settings from config.yaml in $XDG_CONFIG_HOME/pnpm and
+# `pnpm add --global` ignores pnpm-workspace.yaml
+# - https://pnpm.io/settings#minimumreleaseage
+ENV XDG_CONFIG_HOME=/root/.config
+COPY ./docker/pnpm-config.yaml $XDG_CONFIG_HOME/pnpm/config.yaml
+
 RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
 
 COPY ./docker/clone-and-preflight.ts ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN pnpm install --frozen-lockfile
 
 # Apply pnpm's minimumReleaseAge settings to the global install below:
-# pnpm reads global settings from config.yaml in $XDG_CONFIG_HOME/pnpm and
+# pnpm reads global settings from ~/.config/pnpm/config.yaml on Linux and
 # `pnpm add --global` ignores pnpm-workspace.yaml
 # - https://pnpm.io/settings#minimumreleaseage
-ENV XDG_CONFIG_HOME=/root/.config
-COPY ./docker/pnpm-config.yaml $XDG_CONFIG_HOME/pnpm/config.yaml
+# - https://pnpm.io/cli/config
+COPY ./docker/pnpm-global-config.yaml /root/.config/pnpm/config.yaml
 
 RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
 

--- a/docker/pnpm-config.yaml
+++ b/docker/pnpm-config.yaml
@@ -1,0 +1,7 @@
+# Prevents installation of packages newer than 7 days
+# to mitigate supply chain risks, excluding UpLeveled packages so that
+# `pnpm add --global @upleveled/preflight@latest` installs the newest release
+# - https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@upleveled/*'

--- a/docker/pnpm-global-config.yaml
+++ b/docker/pnpm-global-config.yaml
@@ -1,7 +1,9 @@
-# Prevents installation of packages newer than 7 days
-# to mitigate supply chain risks, excluding Preflight so that
-# `pnpm add --global @upleveled/preflight@latest` installs the newest release
+# Prevent installation of packages newer than 7 days
+# to mitigate supply chain risks
 # - https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 10080
+# Exclude Preflight from minimumReleaseAge so that
+# `pnpm add --global @upleveled/preflight@latest`
+# installs latest version
 minimumReleaseAgeExclude:
   - '@upleveled/preflight'

--- a/docker/pnpm-global-config.yaml
+++ b/docker/pnpm-global-config.yaml
@@ -1,7 +1,7 @@
 # Prevents installation of packages newer than 7 days
-# to mitigate supply chain risks, excluding UpLeveled packages so that
+# to mitigate supply chain risks, excluding Preflight so that
 # `pnpm add --global @upleveled/preflight@latest` installs the newest release
 # - https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - '@upleveled/*'
+  - '@upleveled/preflight'

--- a/docker/pnpm-workspace.yaml
+++ b/docker/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-# Prevents installation of packages newer than 7 days
+# Prevent installation of packages newer than 7 days
 # to mitigate supply chain risks
 # - https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 
-# Prevents installation of packages newer than 7 days
+# Prevent installation of packages newer than 7 days
 # to mitigate supply chain risks
 # - https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 10080

--- a/src/checks/preflightIsLatestVersion.ts
+++ b/src/checks/preflightIsLatestVersion.ts
@@ -19,7 +19,7 @@ export default async function preflightIsLatestVersion() {
         ${commandExample(
           `${
             os.platform() === 'linux' ? 'sudo ' : ''
-          }pnpm add --global @upleveled/preflight`,
+          }pnpm add --global @upleveled/preflight@${remoteVersion}`,
         )}
       `,
     );


### PR DESCRIPTION
Closes #772

The `v10.0.1` image was built with Preflight 9.0.13 (see the [v10.0.1 build](https://github.com/upleveled/preflight/actions/runs/33975391952/job/101331071568)):

```bash
#13 [ 8/10] RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
#13 0.538 [WARN] Using --global skips the package manager check for this project
#13 0.773 Progress: resolved 1, reused 0, downloaded 0, added 0
#13 1.775 Progress: resolved 184, reused 14, downloaded 143, added 0
#13 2.007 [WARN] 2 deprecated subdependencies found: node-domexception@1.0.0, whatwg-encoding@3.1.1
#13 2.014 Packages: +208
#13 2.014 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
#13 2.197 Packages are hard linked from the content-addressable store to the virtual store.
#13 2.197   Content-addressable store is at: /pnpm/store/v11
#13 2.197   Virtual store is at:             ../pnpm/store/v11/links
#13 2.654 Progress: resolved 208, reused 14, downloaded 194, added 208, done
#13 2.898 
#13 2.898 global:
#13 2.898 + @upleveled/preflight 9.0.13
#13 2.898 
#13 2.903 Done in 2.7s using pnpm v11.24.0
#13 DONE 3.1s
```

So every project it checks fails the `Preflight is latest version` check ([failing workflow run](https://github.com/upleveled/next-portfolio-dev/actions/runs/33981429311/job/101347224956):

```bash
Run docker run ghcr.io/upleveled/preflight https://github.com/upleveled/next-portfolio-dev main
  docker run ghcr.io/upleveled/preflight https://github.com/upleveled/next-portfolio-dev main
  shell: /usr/bin/bash -e {0}
Cloning https://github.com/upleveled/next-portfolio-dev...
Installing dependencies...
Running Preflight...
🚀 UpLeveled Preflight v9.0.13
[STARTED] All changes committed to Git
[STARTED] node_modules/ folder ignored in Git
[STARTED] No extraneous files committed to Git
[STARTED] No secrets committed to Git
[STARTED] Use single package manager
[COMPLETED] No secrets committed to Git
[STARTED] Project folder name matches correct format
[COMPLETED] Project folder name matches correct format
[STARTED] No dependency problems
[STARTED] No unused dependencies
[STARTED] No dependencies without types
[COMPLETED] No extraneous files committed to Git
[STARTED] GitHub repo has deployed project link under About
[COMPLETED] Use single package manager
[STARTED] ESLint
[COMPLETED] node_modules/ folder ignored in Git
[STARTED] Stylelint
[COMPLETED] All changes committed to Git
[STARTED] Prettier
[COMPLETED] No dependencies without types
[FAILED] Project link in About section on https://github.com/upleveled/next-portfolio-dev is not returning a proper status code: the link returns status code 404 (Not Found).
[STARTED] ESLint config is latest version
[COMPLETED] Prettier
[STARTED] Stylelint config is latest version
[COMPLETED] No unused dependencies
[COMPLETED] No dependency problems
[STARTED] Preflight is latest version
[COMPLETED] Stylelint
[FAILED] Your current version of the UpLeveled ESLint Config (10.0.0) is older than the latest version 10.0.3 - upgrade by running all lines of the install instructions on https://www.npmjs.com/package/eslint-config-upleveled
[COMPLETED] Stylelint config is latest version
[FAILED] Your current version of Preflight (9.0.13) is older than the latest version 10.0.1 - upgrade with:

[FAILED]         ‎  $ sudo pnpm add --global @upleveled/preflight
[COMPLETED] ESLint
Error: Process completed with exit code 1.
```

This is caused by [the pnpm v11 change of the default `minimumReleaseAge` from `0` to `1440` minutes](https://pnpm.io/blog/releases/11.0#security--build-defaults) - `pnpm add --global @upleveled/preflight@latest` in the `Dockerfile` skips every version published in the last 24 hours. At build time 10.0.1 was 1 minute old and 10.0.0 was 1300 minutes old,  leaving 9.0.13 as the installed version (published 2026-04-29).

Configure pnpm `minimumReleaseAge` and `minimumReleaseAgeExclude` globally at `/root/.config/pnpm/config.yaml` for Linux (project-level config with `pnpm-workspace.yaml` can't be used because `pnpm add --global` ignores `pnpm-workspace.yaml`).

Also pin the version in the upgrade command printed by the `Preflight is latest version` check - `sudo pnpm add --global @upleveled/preflight` re-resolves `latest` on the student's machine, installing whatever that yields instead of the version named in the message.

Testing a Docker build from this PR, the image now installs the newest release ([successful Docker build](https://github.com/upleveled/preflight/actions/runs/34029669815/job/101476777542)):

```
#13 [ 8/11] COPY ./docker/pnpm-global-config.yaml /root/.config/pnpm/config.yaml
#13 DONE 0.0s
#14 [ 9/11] RUN pnpm add --global --allow-build=esbuild @upleveled/preflight@latest
#14 0.588 [WARN] Using --global skips the package manager check for this project
#14 1.016 Progress: resolved 1, reused 0, downloaded 0, added 0
#14 2.019 Progress: resolved 135, reused 16, downloaded 103, added 0
#14 2.399 [WARN] 2 deprecated subdependencies found: node-domexception@1.0.0, whatwg-encoding@3.1.1
#14 2.406 Packages: +197
#14 2.406 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
#14 2.444 Packages are hard linked from the content-addressable store to the virtual store.
#14 2.444   Content-addressable store is at: /pnpm/store/v11
#14 2.444   Virtual store is at:             ../pnpm/store/v11/links
#14 2.596 Progress: resolved 197, reused 16, downloaded 181, added 197, done
#14 2.711 
#14 2.711 global:
#14 2.711 + @upleveled/preflight 10.0.1
#14 2.711 
#14 2.717 Done in 2.5s using pnpm v11.24.0
#14 DONE 2.8s
```

- [x] Add `docker/pnpm-global-config.yaml` with `minimumReleaseAge` and an `@upleveled/preflight` exclude
- [x] Edit `Dockerfile` to copy `docker/pnpm-global-config.yaml` to pnpm's global config location `/root/.config/pnpm/config.yaml`
- [x] Add `@<remote version>` to upgrade command in `Preflight is latest version` check output

