### PR TITLE
Switch `pnpm bin` to `import.meta.resolve()` for depcheck ENOENT

### DIFF
--- a/src/checks/noDependencyProblems/noUnusedDependencies.ts
+++ b/src/checks/noDependencyProblems/noUnusedDependencies.ts
@@ -1,6 +1,6 @@
+import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
 import { commandExample } from '../../util/commandExample.ts';
-import { preflightBinPath } from '../../util/preflightBinPath.ts';
 
 export const title = 'No unused dependencies';
 
@@ -71,7 +71,7 @@ export default async function noUnusedAndMissingDependencies() {
   ].join(',');
 
   try {
-    await execa`${preflightBinPath}/depcheck --ignores="${ignoredPackagePatterns}"`;
+    await execa`node ${fileURLToPath(import.meta.resolve('depcheck/bin/depcheck.js'))} --ignores="${ignoredPackagePatterns}"`;
   } catch (error) {
     const { stdout } = error as { stdout: string };
     if (

--- a/src/util/preflightBinPath.ts
+++ b/src/util/preflightBinPath.ts
@@ -1,7 +1,0 @@
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { execa } from 'execa';
-
-export const { stdout: preflightBinPath } = await execa({
-  cwd: dirname(fileURLToPath(import.meta.url)),
-})`pnpm bin`;


### PR DESCRIPTION
Closes #774

`pnpm bin` in pnpm 12 prints `<cwd>/node_modules/.bin` instead of the `node_modules/.bin` of the nearest directory with a `package.json`, so Preflight spawns `depcheck` out of a path which does not exist and projects the image checks fail the `No unused dependencies` check.

Switch resolution of `depcheck` from `pnpm bin` to `import.meta.resolve()` instead, which works across package managers and `node_modules` layouts.

- [x] Replace `pnpm bin` with `import.meta.resolve('depcheck/bin/depcheck.js')`