### PR TITLE
Switch `cd` to `WORKDIR`, reorder Docker `WORKDIR`s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache coreutils git postgresql python3 py3-pip build-base bash
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME/bin:$PATH"
 
-COPY ./docker/package.json ./docker/pnpm-lock.yaml /preflight/
+COPY ./docker/package.json ./docker/pnpm-lock.yaml ./docker/pnpm-workspace.yaml /preflight/
 
 RUN ENV="$HOME/.shrc" SHELL=/bin/sh npx --yes get-pnpm \
     "$(node --input-type=module --eval \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-WORKDIR /preflight
+WORKDIR /
 
 # Avoid interactive prompts eg. from `pnpm install`
 ENV CI=true
@@ -19,12 +19,13 @@ RUN apk add --no-cache coreutils git postgresql python3 py3-pip build-base bash
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME/bin:$PATH"
 
-COPY ./docker/package.json ./docker/pnpm-lock.yaml ./
+COPY ./docker/package.json ./docker/pnpm-lock.yaml /preflight/
 
-RUN cd / \
-  && ENV="$HOME/.shrc" SHELL=/bin/sh npx --yes get-pnpm \
+RUN ENV="$HOME/.shrc" SHELL=/bin/sh npx --yes get-pnpm \
     "$(node --input-type=module --eval \
       'console.log((await import("/preflight/package.json", { with: { type: "json" } })).default.devEngines.packageManager.version)')"
+
+WORKDIR /preflight
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Part of upleveled/courses#3376

PR #777 added `cd /` inside the `get-pnpm` `RUN` instruction because npm refuses to run `get-pnpm` inside the pnpm project. The Docker working directory remains `/preflight` while that shell command runs from `/`:

https://github.com/upleveled/preflight/blob/308f959faa4b0220bb19e2e2265245efdead665c/Dockerfile#L22-L29

Codacy flagged the same `cd /` pattern in the related security example, showing that [this is not best practice](https://docs.docker.com/build/building/best-practices/#workdir) ([failed Codacy check](https://github.com/upleveled/security-vulnerability-examples-next-js-postgres/runs/102230232446)):

```text
Dockerfile:11
Hadolint_DL3003
Use WORKDIR to switch to a directory
RUN cd / \
```

Start the Docker stage at `WORKDIR /`, copy the package manifests to `/preflight`, install the declared pnpm version, then switch once to `WORKDIR /preflight` for project commands ([successful Docker build job for the Winter 2026 example repo](https://github.com/upleveled/next-js-example-winter-2026-eu/actions/runs/34328063245/job/102389875303)):

```text
Run docker build --tag next-js-example-winter-2026-eu .
docker build --tag next-js-example-winter-2026-eu .

#9 [builder  3/10] COPY package.json /app/
#10 [builder  4/10] RUN ENV="$HOME/.shrc" SHELL=/bin/sh npx --yes get-pnpm "$(node ...)"
#10 1.371 ==> Downloading pnpm 11.26.0
#10 DONE 11.0s
#11 [builder  5/10] WORKDIR /app
#11 DONE 0.0s

#16 [runner  3/13] COPY --from=builder /app/package.json /app/
#17 [runner  4/13] RUN ENV="$HOME/.shrc" SHELL=/bin/sh npx --yes get-pnpm "$(node ...)"
#17 1.442 ==> Downloading pnpm 11.26.0
#17 DONE 11.1s
#18 [runner  5/13] WORKDIR /app
#18 DONE 0.1s

#26 naming to docker.io/library/next-js-example-winter-2026-eu done
```

Also, copy the `pnpm-workspace.yaml` to use the pnpm security settings.

- [x] Order the Docker stage from `/` to `/preflight`
- [x] Replace the shell directory change with Docker `WORKDIR`
- [x] Copy the `pnpm-workspace.yaml` to use the pnpm security settings
