### PR TITLE
Remove redundant pnpm 11 settings, clarify Dockerfile pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts-alpine
 
+# Prevent npx get-pnpm EBADDEVENGINES failure from
+# devEngines.packageManager in /preflight/package.json
 WORKDIR /
 
 # Avoid interactive prompts eg. from `pnpm install`

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,15 @@ ENV CI=true
 RUN apk update
 RUN apk add --no-cache coreutils git postgresql python3 py3-pip build-base bash
 
+COPY ./docker/package.json ./docker/pnpm-lock.yaml ./docker/pnpm-workspace.yaml /preflight/
 # Enable `pnpm add --global` on Alpine Linux by setting
 # a dedicated pnpm home directory and adding its bin directory to $PATH
 # https://github.com/pnpm/pnpm/issues/784#issuecomment-1518582235
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME/bin:$PATH"
-
-COPY ./docker/package.json ./docker/pnpm-lock.yaml ./docker/pnpm-workspace.yaml /preflight/
-
 RUN ENV="$HOME/.shrc" SHELL=/bin/sh npx --yes get-pnpm \
-    "$(node --input-type=module --eval \
-      'console.log((await import("/preflight/package.json", { with: { type: "json" } })).default.devEngines.packageManager.version)')"
+  "$(node --input-type=module --eval \
+    'console.log((await import("/preflight/package.json", { with: { type: "json" } })).default.devEngines.packageManager.version)')"
 
 WORKDIR /preflight
 

--- a/docker/pnpm-workspace.yaml
+++ b/docker/pnpm-workspace.yaml
@@ -6,7 +6,3 @@ minimumReleaseAgeExclude:
   - '@upleveled/*'
   - eslint-config-upleveled
   - stylelint-config-upleveled
-
-# Fail on pnpm ignored build scripts
-# - https://pnpm.io/settings#strictdepbuilds
-strictDepBuilds: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ allowBuilds:
 # to mitigate supply chain risks
 # - https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 10080
-minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - '@upleveled/*'
   - eslint-config-upleveled


### PR DESCRIPTION
Part of upleveled/courses#3376

Preflight's root `pnpm-workspace.yaml` explicitly enables `minimumReleaseAgeStrict` even though it defaults to `true` when `minimumReleaseAge` is configured ([root pnpm configuration](https://github.com/upleveled/preflight/blob/49e0ca30ad8162cd4bf2566c0b74a6ff7b5bca68/pnpm-workspace.yaml#L10-L11)). The Docker-specific configuration explicitly enables `strictDepBuilds`, which is the pnpm 11 default ([Docker pnpm configuration](https://github.com/upleveled/preflight/blob/49e0ca30ad8162cd4bf2566c0b74a6ff7b5bca68/docker/pnpm-workspace.yaml#L10-L12)).

Remove both redundant settings so the root and Docker pnpm configuration rely on pnpm 11 defaults.

Also, the Dockerfile does not explain why `WORKDIR /` precedes `npx get-pnpm`, and its package copy separates the pnpm environment variables from the installation command ([Dockerfile](https://github.com/upleveled/preflight/blob/49e0ca30ad8162cd4bf2566c0b74a6ff7b5bca68/Dockerfile#L1-L32)).

Document that `WORKDIR /` prevents an `npx get-pnpm` `EBADDEVENGINES` failure, move the package copy above the contiguous pnpm installation block, and align the command continuation indentation.

- [x] Remove the redundant `minimumReleaseAgeStrict` setting
- [x] Remove the redundant `strictDepBuilds` setting
- [x] Document the `WORKDIR /` requirement
- [x] Group and align the Dockerfile pnpm installation commands
